### PR TITLE
added region filter to welt2000 queries.

### DIFF
--- a/welt2000/welt2000.go
+++ b/welt2000/welt2000.go
@@ -95,6 +95,19 @@ func (wt *Welt2000) GetAirfield(regions []string, updatedSince time.Time) ([]com
 	// summary page, not the actually release source.
 	release.Source = wt.releaseURL
 	err = release.Fetch()
+	// Filter out entries not in the regions.
+	// This could be done more efficiently, but for now we go with post-filter.
+	m := make(map[string]bool) // Use a map as there's no slice.contains(str)
+	for _, v := range regions {
+		m[v] = true
+	}
+	var filtered []common.Airfield
+	for _, a := range release.Airfields {
+		if _, ok := m[a.Region]; ok {
+			filtered = append(filtered, a)
+		}
+	}
+	release.Airfields = filtered
 	glog.V(10).Infof("GetAirfield for regions %v and updatedsince %v retrieved %d results",
 		regions, updatedSince, len(release.Airfields))
 	glog.V(20).Infof("%v", release.Airfields)
@@ -109,6 +122,7 @@ func (wt *Welt2000) PutAirfield(airfields []common.Airfield) error {
 // GetWaypoint follows common.GetWaypoint().
 // FIXME: use region
 func (wt *Welt2000) GetWaypoint(regions []string, updatedSince time.Time) ([]common.Waypoint, error) {
+	glog.V(10).Infof("GetWaypoint with regions %v and updatedSince %v", regions, updatedSince)
 	releases, err := List(wt.rssURL)
 	if err != nil {
 		return nil, err
@@ -122,6 +136,22 @@ func (wt *Welt2000) GetWaypoint(regions []string, updatedSince time.Time) ([]com
 	// summary page, not the actually release source.
 	release.Source = wt.releaseURL
 	err = release.Fetch()
+	// Filter out entries not in the regions.
+	// This could be done more efficiently, but for now we go with post-filter.
+	m := make(map[string]bool) // Use a map as there's no slice.contains(str)
+	for _, v := range regions {
+		m[v] = true
+	}
+	var filtered []common.Waypoint
+	for _, a := range release.Waypoints {
+		if _, ok := m[a.Region]; ok {
+			filtered = append(filtered, a)
+		}
+	}
+	release.Waypoints = filtered
+	glog.V(10).Infof("GetWaypoint for regions %v and updatedsince %v retrieved %d results",
+		regions, updatedSince, len(release.Waypoints))
+	glog.V(20).Infof("%v", release.Waypoints)
 	return release.Waypoints, err
 }
 

--- a/welt2000/welt2000_test.go
+++ b/welt2000/welt2000_test.go
@@ -66,7 +66,7 @@ var getAirfieldTests = []GetAirfieldTest{
 	{"get airfield missing rss",
 		"./t/test-release-basic.txt",
 		"./t/missing-release-list.xml",
-		"CH",
+		"FR",
 		time.Time{},
 		[]common.Airfield{},
 		true,
@@ -74,24 +74,23 @@ var getAirfieldTests = []GetAirfieldTest{
 	{"get airfield missing release",
 		"./t/missing-release.txt",
 		"./t/test-releases-list.xml",
-		"CH",
+		"FR",
 		time.Time{},
 		[]common.Airfield{},
 		true,
 	},
-	//FIXME:
-	/*{"get airfield with missing region",
+	{"get airfield with 0 values for region",
 		"./t/test-release-basic.txt",
 		"./t/test-releases-list.xml",
 		"ZZ",
 		time.Time{},
 		[]common.Airfield{},
-	}*/
+		false,
+	},
 }
 
 func TestGetAirfield(t *testing.T) {
-	for i := range getAirfieldTests {
-		test := getAirfieldTests[i]
+	for _, test := range getAirfieldTests {
 
 		plugin := Welt2000{}
 		cfg := config.Config{}
@@ -100,18 +99,21 @@ func TestGetAirfield(t *testing.T) {
 		err := plugin.Init(cfg)
 		if err != nil {
 			t.Errorf("Failed to initialize plugin :: %v", err)
+			continue
 		}
 
 		var airfields []common.Airfield
 		airfields, err = plugin.GetAirfield([]string{test.rg}, test.d)
 		if err != nil && test.err {
-			return
+			continue
 		} else if err != nil {
 			t.Errorf("Failed to get airfield :: %v", err)
+			continue
 		}
 
 		if len(airfields) != len(test.rs) {
 			t.Errorf("Got %v airfields but expected %v in test '%v'", len(airfields), len(test.rs), test.t)
+			continue
 		}
 
 		for i := range airfields {
@@ -119,6 +121,7 @@ func TestGetAirfield(t *testing.T) {
 			var expected = test.rs[i]
 			if !reflect.DeepEqual(airfield, expected) {
 				t.Errorf("Got wrong airfield. %+v instead of %+v", airfield, expected)
+				continue
 			}
 		}
 	}
@@ -186,14 +189,14 @@ var getWaypointTests = []GetWaypointTest{
 		[]common.Waypoint{},
 		true,
 	},
-	//FIXME:
-	/*{"get waypoint with missing region",
+	{"get waypoint with 0 values for region",
 		"./t/test-release-basic.txt",
 		"./t/test-releases-list.xml",
 		"ZZ",
 		time.Time{},
 		[]common.Waypoint{},
-	},*/
+		false,
+	},
 }
 
 func TestGetWaypoint(t *testing.T) {
@@ -212,13 +215,15 @@ func TestGetWaypoint(t *testing.T) {
 		var waypoints []common.Waypoint
 		waypoints, err = plugin.GetWaypoint([]string{test.rg}, test.d)
 		if err != nil && test.err {
-			return
+			continue
 		} else if err != nil {
 			t.Errorf("Failed to get waypoint :: %v", err)
+			continue
 		}
 
 		if len(waypoints) != len(test.rs) {
 			t.Errorf("Got %v waypoints but expected %v in test '%v'", len(waypoints), len(test.rs), test.t)
+			continue
 		}
 
 		for i := range waypoints {
@@ -226,6 +231,7 @@ func TestGetWaypoint(t *testing.T) {
 			var expected = test.rs[i]
 			if !reflect.DeepEqual(waypoint, expected) {
 				t.Errorf("Got wrong waypoint. %+v instead of %+v", waypoint, expected)
+				continue
 			}
 		}
 	}


### PR DESCRIPTION
getairspace/waypoint queries in the welt2000 plugin now take the list of
regions given into account, removing the results from the release that
do not belong to the given set.

Fixes #38.
