### PR TITLE
refactor flight into its own pkg (was in common).

### DIFF
--- a/cli/flight.go
+++ b/cli/flight.go
@@ -26,8 +26,8 @@ import (
 	"strconv"
 
 	"github.com/golang/glog"
-	"github.com/rochaporto/ezgliding/common"
 	"github.com/rochaporto/ezgliding/context"
+	"github.com/rochaporto/ezgliding/flight"
 
 	commander "code.google.com/p/go-commander"
 )
@@ -55,7 +55,7 @@ func runFlightGet(cmd *commander.Command, args []string) {
 	f := ctx.Flight
 	glog.V(20).Infof("flight plugin instance ::  %v", f)
 
-	var flights []common.Flight
+	var flights []flight.Flight
 	if *startID != "" {
 		vmax := -1
 		// query for flights with ID higher than startID
@@ -72,7 +72,7 @@ func runFlightGet(cmd *commander.Command, args []string) {
 			}
 		}
 		glog.V(10).Infof("querying from start id %v, max %v", sid, vmax)
-		flights, err = f.(common.Flighter).GetFlightFromID(sid, vmax)
+		flights, err = f.(flight.Flighter).GetFlightFromID(sid, vmax)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "failed to get flight :: %v\n", err)
 			return
@@ -85,7 +85,7 @@ func runFlightGet(cmd *commander.Command, args []string) {
 			return
 		}
 		glog.V(10).Infof("querying id %v", sid)
-		flight, err := f.(common.Flighter).GetFlightByID(sid)
+		flight, err := f.(flight.Flighter).GetFlightByID(sid)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "failed to get flight :: %v\n", err)
 			return
@@ -95,10 +95,10 @@ func runFlightGet(cmd *commander.Command, args []string) {
 	}
 	glog.V(5).Infof("flight get with args '%v' got %d results", args, len(flights))
 	glog.V(20).Infof("%+v", flights)
-	for _, flight := range flights {
-		fmt.Printf("%v,%v,%v,%v\n", flight.Header.Date.Format("02/01/2006"),
-			flight.Header.Pilot, flight.Header.GliderType, flight.Header.GliderID)
-		for sourceID, source := range flight.Sources {
+	for _, f := range flights {
+		fmt.Printf("%v,%v,%v,%v\n", f.Header.Date.Format("02/01/2006"),
+			f.Header.Pilot, f.Header.GliderType, f.Header.GliderID)
+		for sourceID, source := range f.Sources {
 			fmt.Printf("\t%v,%v,%v,%v,%v,%v,%v,%v\n", sourceID, source.Name,
 				source.Category, source.Club, source.Country, source.Region,
 				source.Distance, source.Points)

--- a/cli/flight_test.go
+++ b/cli/flight_test.go
@@ -25,8 +25,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/rochaporto/ezgliding/common"
 	"github.com/rochaporto/ezgliding/context"
+	"github.com/rochaporto/ezgliding/flight"
 	"github.com/rochaporto/ezgliding/mock"
 )
 
@@ -36,15 +36,15 @@ import (
 func ExampleFlightGetByID() {
 	ctx := context.Context{
 		Flight: &mock.Mock{
-			GetFlightByIDF: func(id int) (common.Flight, error) {
-				flight := common.Flight{
-					Header: common.Header{
+			GetFlightByIDF: func(id int) (flight.Flight, error) {
+				f := flight.Flight{
+					Header: flight.Header{
 						Date:       time.Date(2015, 1, 10, 0, 0, 0, 0, time.UTC),
 						Pilot:      "MOCK PILOT 1",
 						GliderType: "MOCK GLIDER 1", GliderID: "MOCK ID 1",
 					},
-					Sources: map[string]common.Source{
-						"netcoupe": common.Source{
+					Sources: map[string]flight.Source{
+						"netcoupe": flight.Source{
 							Name:     "MOCK NAME 1",
 							Category: "MOCK CATEGORY 1",
 							Club:     "MOCK CLUB 1",
@@ -54,7 +54,7 @@ func ExampleFlightGetByID() {
 						},
 					},
 				}
-				return flight, nil
+				return f, nil
 			},
 		},
 	}
@@ -78,8 +78,8 @@ func ExampleFlightGetBadID() {
 func ExampleFlightGetMissingID() {
 	ctx := context.Context{
 		Flight: &mock.Mock{
-			GetFlightByIDF: func(id int) (common.Flight, error) {
-				return common.Flight{}, errors.New("given id does not exist")
+			GetFlightByIDF: func(id int) (flight.Flight, error) {
+				return flight.Flight{}, errors.New("given id does not exist")
 			},
 		},
 	}
@@ -94,16 +94,16 @@ func ExampleFlightGetMissingID() {
 func ExampleFlightGetFromID() {
 	ctx := context.Context{
 		Flight: &mock.Mock{
-			GetFlightFromIDF: func(startID int, max int) ([]common.Flight, error) {
-				flights := []common.Flight{
-					common.Flight{
-						Header: common.Header{
+			GetFlightFromIDF: func(startID int, max int) ([]flight.Flight, error) {
+				flights := []flight.Flight{
+					flight.Flight{
+						Header: flight.Header{
 							Date:       time.Date(2015, 1, 10, 0, 0, 0, 0, time.UTC),
 							Pilot:      "MOCK PILOT 1",
 							GliderType: "MOCK GLIDER 1", GliderID: "MOCK ID 1",
 						},
-						Sources: map[string]common.Source{
-							"netcoupe": common.Source{
+						Sources: map[string]flight.Source{
+							"netcoupe": flight.Source{
 								Name:     "MOCK NAME 1",
 								Category: "MOCK CATEGORY 1",
 								Club:     "MOCK CLUB 1",
@@ -113,14 +113,14 @@ func ExampleFlightGetFromID() {
 							},
 						},
 					},
-					common.Flight{
-						Header: common.Header{
+					flight.Flight{
+						Header: flight.Header{
 							Date:       time.Date(2015, 1, 11, 0, 0, 0, 0, time.UTC),
 							Pilot:      "MOCK PILOT 2",
 							GliderType: "MOCK GLIDER 2", GliderID: "MOCK ID 2",
 						},
-						Sources: map[string]common.Source{
-							"netcoupe": common.Source{
+						Sources: map[string]flight.Source{
+							"netcoupe": flight.Source{
 								Name:     "MOCK NAME 2",
 								Category: "MOCK CATEGORY 2",
 								Club:     "MOCK CLUB 2",
@@ -164,8 +164,8 @@ func ExampleFlightGetBadStartID() {
 func ExampleFlightGetMissingStartID() {
 	ctx := context.Context{
 		Flight: &mock.Mock{
-			GetFlightFromIDF: func(startID int, max int) ([]common.Flight, error) {
-				return []common.Flight{}, errors.New("given startID does not exist")
+			GetFlightFromIDF: func(startID int, max int) ([]flight.Flight, error) {
+				return []flight.Flight{}, errors.New("given startID does not exist")
 			},
 		},
 	}
@@ -186,8 +186,8 @@ func ExampleFlightGetBadMax() {
 func TestFlightGetFailed(t *testing.T) {
 	ctx := context.Context{
 		Flight: &mock.Mock{
-			GetFlightByIDF: func(id int) (common.Flight, error) {
-				return common.Flight{}, errors.New("mock testing get flight failed")
+			GetFlightByIDF: func(id int) (flight.Flight, error) {
+				return flight.Flight{}, errors.New("mock testing get flight failed")
 			},
 		},
 	}

--- a/context/context.go
+++ b/context/context.go
@@ -28,6 +28,7 @@ package context
 import (
 	"github.com/rochaporto/ezgliding/common"
 	"github.com/rochaporto/ezgliding/config"
+	"github.com/rochaporto/ezgliding/flight"
 )
 
 // FIXME(rocha): This should really go away.
@@ -42,13 +43,13 @@ type Context struct {
 	Config   config.Config
 	Airspace common.Airspacer
 	Airfield common.Airfielder
-	Flight   common.Flighter
+	Flight   flight.Flighter
 	Waypoint common.Waypointer
 }
 
 // NewContext returns a new Context object.
 func NewContext(cfg config.Config, airspace common.Airspacer, airfield common.Airfielder,
-	flight common.Flighter, waypoint common.Waypointer) (Context, error) {
+	flight flight.Flighter, waypoint common.Waypointer) (Context, error) {
 	return Context{Config: cfg, Airspace: airspace, Airfield: airfield,
 		Flight: flight, Waypoint: waypoint}, nil
 }

--- a/context/context_test.go
+++ b/context/context_test.go
@@ -24,13 +24,14 @@ import (
 
 	"github.com/rochaporto/ezgliding/common"
 	"github.com/rochaporto/ezgliding/config"
+	"github.com/rochaporto/ezgliding/flight"
 	"github.com/rochaporto/ezgliding/mock"
 )
 
 func TestNewContext(t *testing.T) {
 	mock := mock.Mock{}
 	_, err := NewContext(config.Config{}, common.Airspacer(&mock),
-		common.Airfielder(&mock), common.Flighter(&mock),
+		common.Airfielder(&mock), flight.Flighter(&mock),
 		common.Waypointer(&mock))
 	if err != nil {
 		t.Errorf("Failed to get new context :: %v", err)

--- a/flight/flight.go
+++ b/flight/flight.go
@@ -17,7 +17,10 @@
 //
 // Author: Ricardo Rocha <rocha.porto@gmail.com>
 
-package common
+// Package flight holds types and structures related to flight information.
+// This includes the interfaces implemented by flight crawlers as well
+// as all structs used by flight parsers and optimizers.
+package flight
 
 import "time"
 

--- a/igc/parse.go
+++ b/igc/parse.go
@@ -25,14 +25,14 @@ import (
 	"strings"
 	"time"
 
-	"github.com/rochaporto/ezgliding/common"
+	"github.com/rochaporto/ezgliding/flight"
 	"github.com/rochaporto/ezgliding/util"
 )
 
-// Parse returns a common.Flight object corresponding to the given content.
+// Parse returns a flight.Flight object corresponding to the given content.
 // content should be a text string in the IGC format.
-func Parse(content string) (common.Flight, error) {
-	f := common.NewFlight()
+func Parse(content string) (flight.Flight, error) {
+	f := flight.NewFlight()
 	var err error
 	p := Parser{}
 	lines := strings.Split(content, "\n")
@@ -94,7 +94,7 @@ type Parser struct {
 	numSat   int
 }
 
-func (p *Parser) parseA(line string, f *common.Flight) error {
+func (p *Parser) parseA(line string, f *flight.Flight) error {
 	if len(line) < 7 {
 		return fmt.Errorf("line too short :: %v", line)
 	}
@@ -104,11 +104,11 @@ func (p *Parser) parseA(line string, f *common.Flight) error {
 	return nil
 }
 
-func (p *Parser) parseB(line string, f *common.Flight) error {
+func (p *Parser) parseB(line string, f *flight.Flight) error {
 	if len(line) < 37 {
 		return fmt.Errorf("line too short :: %v", line)
 	}
-	pt := common.NewPoint()
+	pt := flight.NewPoint()
 	var err error
 	pt.Time, err = time.Parse(TimeFormat, line[1:7])
 	if err != nil {
@@ -137,7 +137,7 @@ func (p *Parser) parseB(line string, f *common.Flight) error {
 	return nil
 }
 
-func (p *Parser) parseC(lines []string, f *common.Flight) error {
+func (p *Parser) parseC(lines []string, f *flight.Flight) error {
 	line := lines[0]
 	if len(line) < 25 {
 		return fmt.Errorf("wrong line size :: %v", line)
@@ -167,7 +167,7 @@ func (p *Parser) parseC(lines []string, f *common.Flight) error {
 		return err
 	}
 	for i := 0; i < nTP; i++ {
-		var tp common.Point
+		var tp flight.Point
 		if tp, err = p.taskPoint(lines[3+i]); err != nil {
 			return err
 		}
@@ -183,18 +183,18 @@ func (p *Parser) parseC(lines []string, f *common.Flight) error {
 	return nil
 }
 
-func (p *Parser) taskPoint(line string) (common.Point, error) {
+func (p *Parser) taskPoint(line string) (flight.Point, error) {
 	if len(line) < 18 {
-		return common.Point{}, fmt.Errorf("line too short :: %v", line)
+		return flight.Point{}, fmt.Errorf("line too short :: %v", line)
 	}
-	return common.Point{
+	return flight.Point{
 		Latitude:    util.DMS2Decimal(line[1:9]),
 		Longitude:   util.DMS2Decimal(line[9:18]),
 		Description: line[18:],
 	}, nil
 }
 
-func (p *Parser) parseD(line string, f *common.Flight) error {
+func (p *Parser) parseD(line string, f *flight.Flight) error {
 	if len(line) < 6 {
 		return fmt.Errorf("line too short :: %v", line)
 	}
@@ -204,7 +204,7 @@ func (p *Parser) parseD(line string, f *common.Flight) error {
 	return nil
 }
 
-func (p *Parser) parseE(line string, f *common.Flight) error {
+func (p *Parser) parseE(line string, f *flight.Flight) error {
 	if len(line) < 10 {
 		return fmt.Errorf("line too short :: %v", line)
 	}
@@ -219,7 +219,7 @@ func (p *Parser) parseE(line string, f *common.Flight) error {
 	return nil
 }
 
-func (p *Parser) parseF(line string, f *common.Flight) error {
+func (p *Parser) parseF(line string, f *flight.Flight) error {
 	if len(line) < 7 {
 		return fmt.Errorf("line too short :: %v", line)
 	}
@@ -241,12 +241,12 @@ func (p *Parser) parseF(line string, f *common.Flight) error {
 	return nil
 }
 
-func (p *Parser) parseG(line string, f *common.Flight) error {
+func (p *Parser) parseG(line string, f *flight.Flight) error {
 	f.Signature = f.Signature + line[1:]
 	return nil
 }
 
-func (p *Parser) parseH(line string, f *common.Flight) error {
+func (p *Parser) parseH(line string, f *flight.Flight) error {
 	var err error
 	if len(line) < 5 {
 		return fmt.Errorf("line too short :: %v", line)
@@ -339,7 +339,7 @@ func (p *Parser) parseJ(line string) error {
 	return nil
 }
 
-func (p *Parser) parseK(line string, f *common.Flight) error {
+func (p *Parser) parseK(line string, f *flight.Flight) error {
 	if len(line) < 7 {
 		return fmt.Errorf("line too short :: %v", line)
 	}
@@ -355,10 +355,10 @@ func (p *Parser) parseK(line string, f *common.Flight) error {
 	return nil
 }
 
-func (p *Parser) parseL(line string, f *common.Flight) error {
+func (p *Parser) parseL(line string, f *flight.Flight) error {
 	if len(line) < 4 {
 		return fmt.Errorf("line too short :: %v", line)
 	}
-	f.Logbook = append(f.Logbook, common.LogEntry{Type: line[1:4], Text: line[4:]})
+	f.Logbook = append(f.Logbook, flight.LogEntry{Type: line[1:4], Text: line[4:]})
 	return nil
 }

--- a/igc/parse_test.go
+++ b/igc/parse_test.go
@@ -25,13 +25,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/rochaporto/ezgliding/common"
+	"github.com/rochaporto/ezgliding/flight"
 )
 
 type ParseTest struct {
 	t string
 	c string
-	r common.Flight
+	r flight.Flight
 	e bool
 }
 
@@ -55,8 +55,8 @@ HFPRSEZ PRESSURE
 HFCIDEZ COMPID
 HFCCLEZ COMPCLASS
 `,
-		common.Flight{
-			Header: common.Header{
+		flight.Flight{
+			Header: flight.Header{
 				Manufacturer: "FLA", UniqueID: "001", AdditionalData: "Some Additional Data",
 				Date:        time.Date(2003, time.February, 01, 0, 0, 0, 0, time.UTC),
 				FixAccuracy: 500, Pilot: "EZ PILOT", Crew: "EZ CREW",
@@ -69,26 +69,26 @@ HFCCLEZ COMPCLASS
 			K:          map[time.Time]map[string]string{},
 			Events:     map[time.Time]map[string]string{},
 			Satellites: map[time.Time][]int{},
-			Sources:    make(map[string]common.Source),
+			Sources:    make(map[string]flight.Source),
 		},
 		false,
 	},
 	{"A record failure too short",
-		"AFLA0", common.Flight{}, true},
+		"AFLA0", flight.Flight{}, true},
 	{"H record failure too short",
-		"HFFX", common.Flight{}, true},
+		"HFFX", flight.Flight{}, true},
 	{"H record failure bad date",
-		"HFDTE330203", common.Flight{}, true},
+		"HFDTE330203", flight.Flight{}, true},
 	{"H record failure date too short",
-		"HFDTE33", common.Flight{}, true},
+		"HFDTE33", flight.Flight{}, true},
 	{"H record failure bad fix accuracy",
-		"HFFXAAAA", common.Flight{}, true},
+		"HFFXAAAA", flight.Flight{}, true},
 	{"H record failure fix accuracy too short",
-		"HFFXA20", common.Flight{}, true},
+		"HFFXA20", flight.Flight{}, true},
 	{"H record failure gps datum too short",
-		"HFDTM20", common.Flight{}, true},
+		"HFDTM20", flight.Flight{}, true},
 	{"H record failure unknown field",
-		"HFZZZaaa", common.Flight{}, true},
+		"HFZZZaaa", flight.Flight{}, true},
 	{
 		"basic flight test",
 		`
@@ -111,9 +111,9 @@ LPLTLOG TEXT
 GREJNGJERJKNJKRE31895478537H43982FJN9248F942389T433T
 GJNJK2489IERGNV3089IVJE9GO398535J3894N358954983O0934
 `,
-		common.Flight{
-			Points: []common.Point{
-				common.Point{
+		flight.Flight{
+			Points: []flight.Point{
+				flight.Point{
 					Time:     time.Date(0, 1, 1, 16, 2, 45, 0, time.UTC),
 					Latitude: 107.2, Longitude: 15.55, FixValidity: 'A',
 					PressureAltitude: 288, GNSSAltitude: 429,
@@ -122,7 +122,7 @@ GJNJK2489IERGNV3089IVJE9GO398535J3894N358954983O0934
 					},
 					NumSatellites: 6,
 				},
-				common.Point{
+				flight.Point{
 					Time:     time.Date(0, 1, 1, 16, 3, 10, 0, time.UTC),
 					Latitude: 107.35, Longitude: 15.516666666666666,
 					FixValidity: 'V', PressureAltitude: 293, GNSSAltitude: 435,
@@ -145,157 +145,157 @@ GJNJK2489IERGNV3089IVJE9GO398535J3894N358954983O0934
 			Satellites: map[time.Time][]int{
 				time.Date(0, 1, 1, 16, 02, 40, 0, time.UTC): []int{4, 6, 9, 12, 36, 24},
 			},
-			Logbook: []common.LogEntry{
-				common.LogEntry{Type: "PLT", Text: "LOG TEXT"},
+			Logbook: []flight.LogEntry{
+				flight.LogEntry{Type: "PLT", Text: "LOG TEXT"},
 			},
-			Task: common.Task{
+			Task: flight.Task{
 				DeclarationDate: time.Date(2001, time.July, 15, 21, 38, 41, 0, time.UTC),
 				FlightDate:      time.Date(2001, time.July, 16, 0, 0, 0, 0, time.UTC),
 				Number:          1,
-				Takeoff: common.Point{
+				Takeoff: flight.Point{
 					Latitude: 111.58333333333333, Longitude: 10.3,
 					Description: "EZ TAKEOFF"},
-				Start: common.Point{
+				Start: flight.Point{
 					Latitude: 110.28333333333333, Longitude: 10.433333333333334,
 					Description: "EZ START"},
-				Turnpoints: []common.Point{
-					common.Point{
+				Turnpoints: []flight.Point{
+					flight.Point{
 						Latitude: 209.15, Longitude: 25.866666666666667,
 						Description: "EZ TP1"},
-					common.Point{
+					flight.Point{
 						Latitude: 230.23333333333332, Longitude: 2.2666666666666666,
 						Description: "EZ TP2"},
 				},
-				Finish: common.Point{
+				Finish: flight.Point{
 					Latitude: 110.28333333333333, Longitude: 10.433333333333334,
 					Description: "EZ FINISH"},
-				Landing: common.Point{
+				Landing: flight.Point{
 					Latitude: 111.58333333333333, Longitude: 10.3,
 					Description: "EZ LANDING"},
 				Description: "500KTri",
 			},
 			DGPSStationID: "0331",
 			Signature:     "REJNGJERJKNJKRE31895478537H43982FJN9248F942389T433TJNJK2489IERGNV3089IVJE9GO398535J3894N358954983O0934",
-			Sources:       make(map[string]common.Source),
+			Sources:       make(map[string]flight.Source),
 		},
 		false,
 	},
 	{"point/fix wrong size",
-		"B110001", common.Flight{}, true},
+		"B110001", flight.Flight{}, true},
 	{"point/fix bad time",
-		"B3103105107212N00149174WV002930043519608024", common.Flight{}, true},
+		"B3103105107212N00149174WV002930043519608024", flight.Flight{}, true},
 	{"point/fix bad fix validity",
-		"B1603105107212N00149174WX002930043519608024", common.Flight{}, true},
+		"B1603105107212N00149174WX002930043519608024", flight.Flight{}, true},
 	{"point/fix bad pressure altitude",
-		"B1603105107212N00149174WV0029a0043519608024", common.Flight{}, true},
+		"B1603105107212N00149174WV0029a0043519608024", flight.Flight{}, true},
 	{"point/fix bad gnss altitude",
-		"B1603105107212N00149174WV002930043a19608024", common.Flight{}, true},
+		"B1603105107212N00149174WV002930043a19608024", flight.Flight{}, true},
 	{"irecord wrong size",
-		"I0", common.Flight{}, true},
+		"I0", flight.Flight{}, true},
 	{"irecord invalid value for field number",
-		"I0a", common.Flight{}, true},
+		"I0a", flight.Flight{}, true},
 	{"irecord wrong size with fields",
-		"I02AAA0102BBB030", common.Flight{}, true},
+		"I02AAA0102BBB030", flight.Flight{}, true},
 	{"jrecord wrong size",
-		"J0", common.Flight{}, true},
+		"J0", flight.Flight{}, true},
 	{"jrecord invalid value for field number",
-		"J0a", common.Flight{}, true},
+		"J0a", flight.Flight{}, true},
 	{"jrecord wrong size with fields",
-		"J02AAA0102BBB030", common.Flight{}, true},
+		"J02AAA0102BBB030", flight.Flight{}, true},
 	{"k wrong size",
-		"K16024", common.Flight{}, true},
+		"K16024", flight.Flight{}, true},
 	{"k invalid date",
-		"K160271", common.Flight{}, true},
+		"K160271", flight.Flight{}, true},
 	{"k wrong size",
-		"K16027000090", common.Flight{}, true},
+		"K16027000090", flight.Flight{}, true},
 	{"e wrong size",
-		"E16024", common.Flight{}, true},
+		"E16024", flight.Flight{}, true},
 	{"e invalid date",
-		"E160271ATS", common.Flight{}, true},
+		"E160271ATS", flight.Flight{}, true},
 	{"f wrong size",
-		"F16024", common.Flight{}, true},
+		"F16024", flight.Flight{}, true},
 	{"f invalid date",
-		"F1602710102", common.Flight{}, true},
+		"F1602710102", flight.Flight{}, true},
 	{"f invalid num satellites",
-		"F1602310a02", common.Flight{}, true},
+		"F1602310a02", flight.Flight{}, true},
 	{"l wrong size",
-		"LPL", common.Flight{}, true},
+		"LPL", flight.Flight{}, true},
 	{"c bad num lines",
-		"C150701213841160701000102500KTri", common.Flight{}, true},
+		"C150701213841160701000102500KTri", flight.Flight{}, true},
 	{"c wrong size first line",
-		"C15070121384116070100010", common.Flight{}, true},
+		"C15070121384116070100010", flight.Flight{}, true},
 	{"c invalid num of tps",
-		"C15070121384116070100010a", common.Flight{}, true},
+		"C15070121384116070100010a", flight.Flight{}, true},
 	{"c invalid declaration date",
-		"C350701213841160701000102500KTri\nC5111359N00101899WEZ TAKEOFF\nC5110179N00102644WEZ START\nC5209092N00255227WEZ TP1\nC5230147N00017612WEZ TP2\nC5110179N00102644WEZ FINISH\nC5111359N00101899WEZ LANDING", getFlight(common.Task{
+		"C350701213841160701000102500KTri\nC5111359N00101899WEZ TAKEOFF\nC5110179N00102644WEZ START\nC5209092N00255227WEZ TP1\nC5230147N00017612WEZ TP2\nC5110179N00102644WEZ FINISH\nC5111359N00101899WEZ LANDING", getFlight(flight.Task{
 			DeclarationDate: time.Time{},
 			FlightDate:      time.Date(2001, time.July, 16, 0, 0, 0, 0, time.UTC),
 			Number:          1,
-			Takeoff: common.Point{
+			Takeoff: flight.Point{
 				Latitude: 111.58333333333333, Longitude: 10.3,
 				Description: "EZ TAKEOFF"},
-			Start: common.Point{
+			Start: flight.Point{
 				Latitude: 110.28333333333333, Longitude: 10.433333333333334,
 				Description: "EZ START"},
-			Turnpoints: []common.Point{
-				common.Point{
+			Turnpoints: []flight.Point{
+				flight.Point{
 					Latitude: 209.15, Longitude: 25.866666666666667,
 					Description: "EZ TP1"},
-				common.Point{
+				flight.Point{
 					Latitude: 230.23333333333332, Longitude: 2.2666666666666666,
 					Description: "EZ TP2"},
 			},
-			Finish: common.Point{
+			Finish: flight.Point{
 				Latitude: 110.28333333333333, Longitude: 10.433333333333334,
 				Description: "EZ FINISH"},
-			Landing: common.Point{
+			Landing: flight.Point{
 				Latitude: 111.58333333333333, Longitude: 10.3,
 				Description: "EZ LANDING"},
 			Description: "500KTri",
 		}), false},
 	{"c invalid flight date",
-		"C150701213841360701000102500KTri\nC5111359N00101899WEZ TAKEOFF\nC5110179N00102644WEZ START\nC5209092N00255227WEZ TP1\nC5230147N00017612WEZ TP2\nC5110179N00102644WEZ FINISH\nC5111359N00101899WEZ LANDING", getFlight(common.Task{
+		"C150701213841360701000102500KTri\nC5111359N00101899WEZ TAKEOFF\nC5110179N00102644WEZ START\nC5209092N00255227WEZ TP1\nC5230147N00017612WEZ TP2\nC5110179N00102644WEZ FINISH\nC5111359N00101899WEZ LANDING", getFlight(flight.Task{
 			DeclarationDate: time.Date(2001, time.July, 15, 21, 38, 41, 0, time.UTC),
 			FlightDate:      time.Time{},
 			Number:          1,
-			Takeoff: common.Point{
+			Takeoff: flight.Point{
 				Latitude: 111.58333333333333, Longitude: 10.3,
 				Description: "EZ TAKEOFF"},
-			Start: common.Point{
+			Start: flight.Point{
 				Latitude: 110.28333333333333, Longitude: 10.433333333333334,
 				Description: "EZ START"},
-			Turnpoints: []common.Point{
-				common.Point{
+			Turnpoints: []flight.Point{
+				flight.Point{
 					Latitude: 209.15, Longitude: 25.866666666666667,
 					Description: "EZ TP1"},
-				common.Point{
+				flight.Point{
 					Latitude: 230.23333333333332, Longitude: 2.2666666666666666,
 					Description: "EZ TP2"},
 			},
-			Finish: common.Point{
+			Finish: flight.Point{
 				Latitude: 110.28333333333333, Longitude: 10.433333333333334,
 				Description: "EZ FINISH"},
-			Landing: common.Point{
+			Landing: flight.Point{
 				Latitude: 111.58333333333333, Longitude: 10.3,
 				Description: "EZ LANDING"},
 			Description: "500KTri",
 		}), false},
 	{"c invalid task number",
-		"C150701213841160701000a01500KTri\nC5111359N00101899WEZ TAKEOFF\nC5110179N00102644WEZ START\nC5209092N00255227WEZ TP1\nC5110179N00102644WEZ FINISH\nC5111359N00101899WEZ LANDING", common.Flight{}, true},
+		"C150701213841160701000a01500KTri\nC5111359N00101899WEZ TAKEOFF\nC5110179N00102644WEZ START\nC5209092N00255227WEZ TP1\nC5110179N00102644WEZ FINISH\nC5111359N00101899WEZ LANDING", flight.Flight{}, true},
 	{"c invalid takeoff",
-		"C150701213841160701000101500KTri\nC5111359N00101899\nC5110179N00102644WEZ START\nC5209092N00255227WEZ TP1\nC5110179N00102644WEZ FINISH\nC5111359N00101899WEZ LANDING", common.Flight{}, true},
+		"C150701213841160701000101500KTri\nC5111359N00101899\nC5110179N00102644WEZ START\nC5209092N00255227WEZ TP1\nC5110179N00102644WEZ FINISH\nC5111359N00101899WEZ LANDING", flight.Flight{}, true},
 	{"c invalid start",
-		"C150701213841160701000101500KTri\nC5111359N00101899WEZ TAKEOFF\nC5110179N00102644\nC5209092N00255227WEZ TP1\nC5110179N00102644WEZ FINISH\nC5111359N00101899WEZ LANDING", common.Flight{}, true},
+		"C150701213841160701000101500KTri\nC5111359N00101899WEZ TAKEOFF\nC5110179N00102644\nC5209092N00255227WEZ TP1\nC5110179N00102644WEZ FINISH\nC5111359N00101899WEZ LANDING", flight.Flight{}, true},
 	{"c invalid tp",
-		"C150701213841160701000101500KTri\nC5111359N00101899WEZ TAKEOFF\nC5110179N00102644WEZ START\nC5209092N00255227\nC5110179N00102644WEZ FINISH\nC5111359N00101899WEZ LANDING", common.Flight{}, true},
+		"C150701213841160701000101500KTri\nC5111359N00101899WEZ TAKEOFF\nC5110179N00102644WEZ START\nC5209092N00255227\nC5110179N00102644WEZ FINISH\nC5111359N00101899WEZ LANDING", flight.Flight{}, true},
 	{"c invalid finish",
-		"C150701213841160701000101500KTri\nC5111359N00101899WEZ TAKEOFF\nC5110179N00102644WEZ START\nC5209092N00255227WEZ TP1\nC5110179N00102644\nC5111359N00101899WEZ LANDING", common.Flight{}, true},
+		"C150701213841160701000101500KTri\nC5111359N00101899WEZ TAKEOFF\nC5110179N00102644WEZ START\nC5209092N00255227WEZ TP1\nC5110179N00102644\nC5111359N00101899WEZ LANDING", flight.Flight{}, true},
 	{"c invalid landing",
-		"C150701213841160701000101500KTri\nC5111359N00101899WEZ TAKEOFF\nC5110179N00102644WEZ START\nC5209092N00255227WEZ TP1\nC5110179N00102644WEZ FINISH\nC5111359N00101899", common.Flight{}, true},
+		"C150701213841160701000101500KTri\nC5111359N00101899WEZ TAKEOFF\nC5110179N00102644WEZ START\nC5209092N00255227WEZ TP1\nC5110179N00102644WEZ FINISH\nC5111359N00101899", flight.Flight{}, true},
 	{"d wrong size",
-		"D2033", common.Flight{}, true},
+		"D2033", flight.Flight{}, true},
 	{"invalid record",
-		"RANDOM GARBAGE", common.Flight{}, true},
+		"RANDOM GARBAGE", flight.Flight{}, true},
 }
 
 func TestParse(t *testing.T) {
@@ -326,8 +326,8 @@ func BenchmarkParse(b *testing.B) {
 	}
 }
 
-func getFlight(task common.Task) common.Flight {
-	flight := common.NewFlight()
-	flight.Task = task
-	return flight
+func getFlight(task flight.Task) flight.Flight {
+	f := flight.NewFlight()
+	f.Task = task
+	return f
 }

--- a/main.go
+++ b/main.go
@@ -28,6 +28,7 @@ import (
 	"github.com/rochaporto/ezgliding/common"
 	"github.com/rochaporto/ezgliding/config"
 	"github.com/rochaporto/ezgliding/context"
+	"github.com/rochaporto/ezgliding/flight"
 	"github.com/rochaporto/ezgliding/plugin"
 )
 
@@ -46,14 +47,14 @@ func main() {
 	}
 	airspace, err := plugin.NewPlugin(plugin.ID(cfg.Global.Airspacer))
 	airfield, err := plugin.NewPlugin(plugin.ID(cfg.Global.Airfielder))
-	flight, err := plugin.NewPlugin(plugin.ID(cfg.Global.Flighter))
+	fght, err := plugin.NewPlugin(plugin.ID(cfg.Global.Flighter))
 	waypoint, err := plugin.NewPlugin(plugin.ID(cfg.Global.Waypointer))
 	airspace.Init(cfg)
 	airfield.Init(cfg)
-	flight.Init(cfg)
+	fght.Init(cfg)
 	waypoint.Init(cfg)
 	ctx, err := context.NewContext(cfg, airspace.(common.Airspacer),
-		airfield.(common.Airfielder), flight.(common.Flighter),
+		airfield.(common.Airfielder), fght.(flight.Flighter),
 		waypoint.(common.Waypointer))
 	if err != nil {
 		glog.Errorf("Failed to create context object :: %v", err)

--- a/mock/flight.go
+++ b/mock/flight.go
@@ -22,37 +22,37 @@ package mock
 import (
 	"time"
 
-	"github.com/rochaporto/ezgliding/common"
+	"github.com/rochaporto/ezgliding/flight"
 )
 
-// GetFlight is the mock implementation of common.Flighter.GetFlight.
-func (mk *Mock) GetFlight(regions []string, updatedSince time.Time) ([]common.Flight, error) {
+// GetFlight is the mock implementation of flight.Flighter.GetFlight.
+func (mk *Mock) GetFlight(regions []string, updatedSince time.Time) ([]flight.Flight, error) {
 	if mk.GetFlightF != nil {
 		return mk.GetFlightF(regions, updatedSince)
 	}
-	return []common.Flight{}, nil
+	return []flight.Flight{}, nil
 }
 
-// GetFlightFromID is the mock implementation of common.Flighter.GetFlightFromID.
-func (mk *Mock) GetFlightFromID(startID int, max int) ([]common.Flight, error) {
+// GetFlightFromID is the mock implementation of flight.Flighter.GetFlightFromID.
+func (mk *Mock) GetFlightFromID(startID int, max int) ([]flight.Flight, error) {
 	if mk.GetFlightFromIDF != nil {
 		return mk.GetFlightFromIDF(startID, max)
 	}
-	return []common.Flight{}, nil
+	return []flight.Flight{}, nil
 }
 
-// GetFlightByID is the mock implementation of common.Flighter.GetFlightByID.
-func (mk *Mock) GetFlightByID(id int) (common.Flight, error) {
+// GetFlightByID is the mock implementation of flight.Flighter.GetFlightByID.
+func (mk *Mock) GetFlightByID(id int) (flight.Flight, error) {
 	if mk.GetFlightByIDF != nil {
 		return mk.GetFlightByIDF(id)
 	}
-	return common.Flight{}, nil
+	return flight.Flight{}, nil
 }
 
-// PutFlight is the mock implementation of common.Flighter.PutFlight.
-func (mk *Mock) PutFlight(flight []common.Flight) error {
+// PutFlight is the mock implementation of flight.Flighter.PutFlight.
+func (mk *Mock) PutFlight(f []flight.Flight) error {
 	if mk.PutFlightF != nil {
-		return mk.PutFlightF(flight)
+		return mk.PutFlightF(f)
 	}
 	return nil
 }

--- a/mock/flight_test.go
+++ b/mock/flight_test.go
@@ -24,15 +24,15 @@ import (
 	"testing"
 	"time"
 
-	"github.com/rochaporto/ezgliding/common"
+	"github.com/rochaporto/ezgliding/flight"
 )
 
 func TestGetFlight(t *testing.T) {
-	flights := []common.Flight{
-		common.Flight{Header: common.Header{UniqueID: "MockUniqueID"}},
+	flights := []flight.Flight{
+		flight.Flight{Header: flight.Header{UniqueID: "MockUniqueID"}},
 	}
 	mock := Mock{
-		GetFlightF: func(regions []string, updatedSince time.Time) ([]common.Flight, error) {
+		GetFlightF: func(regions []string, updatedSince time.Time) ([]flight.Flight, error) {
 			return flights, nil
 		},
 	}
@@ -57,11 +57,11 @@ func TestGetFlightNotImplemented(t *testing.T) {
 }
 
 func TestGetFlightFromID(t *testing.T) {
-	flights := []common.Flight{
-		common.Flight{Header: common.Header{UniqueID: "MockUniqueID"}},
+	flights := []flight.Flight{
+		flight.Flight{Header: flight.Header{UniqueID: "MockUniqueID"}},
 	}
 	mock := Mock{
-		GetFlightFromIDF: func(startID int, max int) ([]common.Flight, error) {
+		GetFlightFromIDF: func(startID int, max int) ([]flight.Flight, error) {
 			return flights, nil
 		},
 	}
@@ -86,18 +86,18 @@ func TestGetFlightFromIDNotImplemented(t *testing.T) {
 }
 
 func TestGetFlightByID(t *testing.T) {
-	flight := common.Flight{Header: common.Header{UniqueID: "MockUniqueID"}}
+	f := flight.Flight{Header: flight.Header{UniqueID: "MockUniqueID"}}
 	mock := Mock{
-		GetFlightByIDF: func(id int) (common.Flight, error) {
-			return flight, nil
+		GetFlightByIDF: func(id int) (flight.Flight, error) {
+			return f, nil
 		},
 	}
 	result, err := mock.GetFlightByID(10)
 	if err != nil {
 		t.Errorf("failed to query mock flights")
 	}
-	if !reflect.DeepEqual(result, flight) {
-		t.Errorf("got %v but expected %v", result, flight)
+	if !reflect.DeepEqual(result, f) {
+		t.Errorf("got %v but expected %v", result, f)
 	}
 }
 
@@ -107,19 +107,19 @@ func TestGetFlightByIDNotImplemented(t *testing.T) {
 	if err != nil {
 		t.Errorf("failed to get flight :: %v", err)
 	}
-	flight := common.Flight{}
-	if !reflect.DeepEqual(result, flight) {
+	f := flight.Flight{}
+	if !reflect.DeepEqual(result, f) {
 		t.Errorf("expected empty flight but got %v", result)
 	}
 }
 
 func TestPutFlight(t *testing.T) {
-	flights := []common.Flight{
-		common.Flight{Header: common.Header{UniqueID: "MockUniqueID"}},
+	flights := []flight.Flight{
+		flight.Flight{Header: flight.Header{UniqueID: "MockUniqueID"}},
 	}
-	var result []common.Flight
+	var result []flight.Flight
 	mock := Mock{
-		PutFlightF: func(a []common.Flight) error {
+		PutFlightF: func(a []flight.Flight) error {
 			result = a
 			return nil
 		},

--- a/mock/mock.go
+++ b/mock/mock.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/rochaporto/ezgliding/common"
 	"github.com/rochaporto/ezgliding/config"
+	"github.com/rochaporto/ezgliding/flight"
 )
 
 const (
@@ -41,10 +42,10 @@ type Mock struct {
 	PutAirfieldF     func(airfield []common.Airfield) error
 	GetAirspaceF     func(regions []string, updatedSince time.Time) ([]common.Airspace, error)
 	PutAirspaceF     func(airspace []common.Airspace) error
-	GetFlightF       func(regions []string, updatedSince time.Time) ([]common.Flight, error)
-	GetFlightFromIDF func(startID int, max int) ([]common.Flight, error)
-	GetFlightByIDF   func(id int) (common.Flight, error)
-	PutFlightF       func(flights []common.Flight) error
+	GetFlightF       func(regions []string, updatedSince time.Time) ([]flight.Flight, error)
+	GetFlightFromIDF func(startID int, max int) ([]flight.Flight, error)
+	GetFlightByIDF   func(id int) (flight.Flight, error)
+	PutFlightF       func(flights []flight.Flight) error
 	GetWaypointF     func(regions []string, updatedSince time.Time) ([]common.Waypoint, error)
 	PutWaypointF     func(waypoint []common.Waypoint) error
 }

--- a/netcoupe/netcoupe_test.go
+++ b/netcoupe/netcoupe_test.go
@@ -29,8 +29,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/rochaporto/ezgliding/common"
 	"github.com/rochaporto/ezgliding/config"
+	"github.com/rochaporto/ezgliding/flight"
 )
 
 func TestInit(t *testing.T) {
@@ -75,19 +75,19 @@ func TestInitDefault(t *testing.T) {
 type GetFlightByIDTest struct {
 	t   string
 	id  int
-	r   common.Source
+	r   flight.Source
 	err bool
 }
 
 var getFlightByIDTests = []GetFlightByIDTest{
 	GetFlightByIDTest{t: "basic get flight by id", id: 1, r: getSource(1), err: false},
-	GetFlightByIDTest{t: "non existing get flight by id", id: 999, r: common.Source{}, err: true},
-	GetFlightByIDTest{t: "bad date get flight by id", id: 300, r: common.Source{}, err: true},
-	GetFlightByIDTest{t: "bad distance get flight by id", id: 301, r: common.Source{}, err: true},
-	GetFlightByIDTest{t: "bad points get flight by id", id: 302, r: common.Source{}, err: true},
-	GetFlightByIDTest{t: "bad speed get flight by id", id: 303, r: common.Source{}, err: true},
-	GetFlightByIDTest{t: "malformed flight get flight by id", id: 305, r: common.Source{}, err: true},
-	GetFlightByIDTest{t: "bad location get flight by id", id: 306, r: common.Source{}, err: true},
+	GetFlightByIDTest{t: "non existing get flight by id", id: 999, r: flight.Source{}, err: true},
+	GetFlightByIDTest{t: "bad date get flight by id", id: 300, r: flight.Source{}, err: true},
+	GetFlightByIDTest{t: "bad distance get flight by id", id: 301, r: flight.Source{}, err: true},
+	GetFlightByIDTest{t: "bad points get flight by id", id: 302, r: flight.Source{}, err: true},
+	GetFlightByIDTest{t: "bad speed get flight by id", id: 303, r: flight.Source{}, err: true},
+	GetFlightByIDTest{t: "malformed flight get flight by id", id: 305, r: flight.Source{}, err: true},
+	GetFlightByIDTest{t: "bad location get flight by id", id: 306, r: flight.Source{}, err: true},
 }
 
 func TestGetFlightByID(t *testing.T) {
@@ -100,7 +100,7 @@ func TestGetFlightByID(t *testing.T) {
 		return
 	}
 	for _, test := range getFlightByIDTests {
-		var flight common.Flight
+		var flight flight.Flight
 		var err error
 		flight, err = nc.GetFlightByID(test.id)
 		if err != nil && test.err {
@@ -173,19 +173,19 @@ type GetFlightFromIDTest struct {
 	t   string
 	sid int
 	max int
-	r   []common.Source
+	r   []flight.Source
 	err bool
 }
 
 var getFlightFromIDTests = []GetFlightFromIDTest{
 	GetFlightFromIDTest{
-		t: "basic get flight from id", sid: 2, max: -1, r: []common.Source{getSource(2), getSource(5)}, err: false,
+		t: "basic get flight from id", sid: 2, max: -1, r: []flight.Source{getSource(2), getSource(5)}, err: false,
 	},
 	GetFlightFromIDTest{
-		t: "get flight from id with max", sid: 2, max: 1, r: []common.Source{getSource(2)}, err: false,
+		t: "get flight from id with max", sid: 2, max: 1, r: []flight.Source{getSource(2)}, err: false,
 	},
 	GetFlightFromIDTest{
-		t: "get flight from id with max 0", sid: 2, max: 0, r: []common.Source{}, err: false,
+		t: "get flight from id with max 0", sid: 2, max: 0, r: []flight.Source{}, err: false,
 	},
 }
 
@@ -206,7 +206,7 @@ func TestGetFlightFromID(t *testing.T) {
 			t.Errorf("failed to get flight from id :: %v", err)
 			return
 		}
-		sources := []common.Source{}
+		sources := []flight.Source{}
 		for _, flight := range flights {
 			sources = append(sources, flight.Sources[ID])
 		}
@@ -235,26 +235,26 @@ func TestPutFlightNotImplemented(t *testing.T) {
 		t.Errorf("init failed :: %v", err)
 		return
 	}
-	if err := nc.PutFlight([]common.Flight{}); err == nil {
+	if err := nc.PutFlight([]flight.Flight{}); err == nil {
 		t.Errorf("expected error but got success")
 		return
 	}
 
 }
 
-func getSource(id int) common.Source {
+func getSource(id int) flight.Source {
 	sid := strconv.Itoa(id)
-	return common.Source{
+	return flight.Source{
 		Name: "PILOT " + sid, Category: "CATEGORY " + sid, Club: "CLUB " + sid,
 		Region: "REGION " + sid, Country: "COUNTRY " + sid,
 		Date:    time.Date(2015, time.Month(id), id, 0, 0, 0, 0, time.UTC),
 		Takeoff: "TAKEOFF " + sid, Distance: 100.10 + float64(id), Points: 100.20 + float64(id),
 		Type: "TYPE " + sid, CircuitType: "CIRCUIT TYPE " + sid,
 		Speed: 100.30 + float64(id), Start: "START " + sid, Finish: "FINISH " + sid,
-		Turnpoints: []common.Point{
-			common.Point{Description: "POINT1 " + sid},
-			common.Point{Description: "POINT2 " + sid},
-			common.Point{Description: "POINT3 " + sid},
+		Turnpoints: []flight.Point{
+			flight.Point{Description: "POINT1 " + sid},
+			flight.Point{Description: "POINT2 " + sid},
+			flight.Point{Description: "POINT3 " + sid},
 		},
 		Comment:     "COMMENTS " + sid,
 		DownloadURL: "/Results/DownloadIGC.aspx?FileID=" + sid,


### PR DESCRIPTION
moves all flight related types and structures from common to their own
flight pkg (common.Flight, common.Header, common.Task, ...). this is
part of the refactor effort to get rid of common.

Implements #69.