### PR TITLE
refactor airspace into their own pkg (was in common).

### DIFF
--- a/airspace/airspace.go
+++ b/airspace/airspace.go
@@ -17,11 +17,8 @@
 //
 // Author: Ricardo Rocha <rocha.porto@gmail.com>
 
-// Package common provides common functionality and interfaces.
-//
-// It includes methods to manage airfield, airspace and waypoint
-// data, as well as other utility libraries.
-package common
+// Package airspace provides airspace related interfaces and types.//
+package airspace
 
 import (
 	"image/color"
@@ -51,12 +48,12 @@ type Airspace struct {
 	Ceiling  string
 	Floor    string
 	Label    []string
-	Segments []AirspaceSegment
+	Segments []Segment
 	Pen      Pen
 	Update   time.Time
 }
 
-// AirspaceSegment is one of polygon, arc, circle.
+// Segment is one of polygon, arc, circle.
 //
 // Clockwise indicates direction for building arcs.
 //
@@ -67,8 +64,8 @@ type Airspace struct {
 //   Arc: radius, start, end || coordinate1, coordinate2 (center in X)
 //   Circle: radius (from X)
 //
-type AirspaceSegment struct {
-	Type        AirspaceSegmentType
+type Segment struct {
+	Type        SegmentType
 	Clockwise   bool
 	X           string
 	W           int
@@ -79,12 +76,12 @@ type AirspaceSegment struct {
 	Coordinate2 string
 }
 
-// AirspaceSegmentType is an int for an AirspaceSegment.
-type AirspaceSegmentType int
+// SegmentType is an int for an AirspaceSegment.
+type SegmentType int
 
 // Constants for airspace record types
 const (
-	Polygon AirspaceSegmentType = iota
+	Polygon SegmentType = iota
 	Arc
 	Circle
 )

--- a/cli/airspace.go
+++ b/cli/airspace.go
@@ -27,7 +27,7 @@ import (
 
 	commander "code.google.com/p/go-commander"
 	"github.com/golang/glog"
-	"github.com/rochaporto/ezgliding/common"
+	"github.com/rochaporto/ezgliding/airspace"
 	"github.com/rochaporto/ezgliding/context"
 )
 
@@ -49,8 +49,8 @@ Example:
 func runAirspaceGet(cmd *commander.Command, args []string) {
 	var err error
 	ctx := context.Ctx
-	airspace := ctx.Airspace
-	airspaces, err := airspace.(common.Airspacer).GetAirspace(strings.Split(*region, ","), time.Time{})
+	aspace := ctx.Airspace
+	airspaces, err := aspace.(airspace.Airspacer).GetAirspace(strings.Split(*region, ","), time.Time{})
 	if err != nil {
 		glog.Errorf("Failed to get airspace :: %v", err)
 		// FIXME: must return -1, but no way now to check this in test

--- a/cli/airspace_test.go
+++ b/cli/airspace_test.go
@@ -24,7 +24,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/rochaporto/ezgliding/common"
+	"github.com/rochaporto/ezgliding/airspace"
 	"github.com/rochaporto/ezgliding/context"
 	"github.com/rochaporto/ezgliding/mock"
 )
@@ -35,9 +35,9 @@ import (
 func ExampleAirspaceGet() {
 	ctx := context.Context{
 		Airspace: &mock.Mock{
-			GetAirspaceF: func(regions []string, updatedSince time.Time) ([]common.Airspace, error) {
-				return []common.Airspace{
-					common.Airspace{ID: "MockID", Date: time.Time{}, Class: 'C', Name: "MockName",
+			GetAirspaceF: func(regions []string, updatedSince time.Time) ([]airspace.Airspace, error) {
+				return []airspace.Airspace{
+					airspace.Airspace{ID: "MockID", Date: time.Time{}, Class: 'C', Name: "MockName",
 						Ceiling: "1000FT AMSL", Floor: "500FT AMSL", Update: time.Time{}},
 				}, nil
 			},
@@ -51,7 +51,7 @@ func ExampleAirspaceGet() {
 func TestAirspaceGetFailed(t *testing.T) {
 	ctx := context.Context{
 		Airspace: &mock.Mock{
-			GetAirspaceF: func(regions []string, updatedSince time.Time) ([]common.Airspace, error) {
+			GetAirspaceF: func(regions []string, updatedSince time.Time) ([]airspace.Airspace, error) {
 				return nil, errors.New("mock testing get airspace failed")
 			},
 		},

--- a/context/context.go
+++ b/context/context.go
@@ -27,7 +27,7 @@ package context
 
 import (
 	"github.com/rochaporto/ezgliding/airfield"
-	"github.com/rochaporto/ezgliding/common"
+	"github.com/rochaporto/ezgliding/airspace"
 	"github.com/rochaporto/ezgliding/config"
 	"github.com/rochaporto/ezgliding/flight"
 	"github.com/rochaporto/ezgliding/waypoint"
@@ -43,14 +43,14 @@ var Ctx Context
 // Context holds all information required between multiple calls.
 type Context struct {
 	Config   config.Config
-	Airspace common.Airspacer
+	Airspace airspace.Airspacer
 	Airfield airfield.Airfielder
 	Flight   flight.Flighter
 	Waypoint waypoint.Waypointer
 }
 
 // NewContext returns a new Context object.
-func NewContext(cfg config.Config, airspace common.Airspacer, airfield airfield.Airfielder,
+func NewContext(cfg config.Config, airspace airspace.Airspacer, airfield airfield.Airfielder,
 	flight flight.Flighter, waypoint waypoint.Waypointer) (Context, error) {
 	return Context{Config: cfg, Airspace: airspace, Airfield: airfield,
 		Flight: flight, Waypoint: waypoint}, nil

--- a/context/context_test.go
+++ b/context/context_test.go
@@ -23,7 +23,7 @@ import (
 	"testing"
 
 	"github.com/rochaporto/ezgliding/airfield"
-	"github.com/rochaporto/ezgliding/common"
+	"github.com/rochaporto/ezgliding/airspace"
 	"github.com/rochaporto/ezgliding/config"
 	"github.com/rochaporto/ezgliding/flight"
 	"github.com/rochaporto/ezgliding/mock"
@@ -32,7 +32,7 @@ import (
 
 func TestNewContext(t *testing.T) {
 	mock := mock.Mock{}
-	_, err := NewContext(config.Config{}, common.Airspacer(&mock),
+	_, err := NewContext(config.Config{}, airspace.Airspacer(&mock),
 		airfield.Airfielder(&mock), flight.Flighter(&mock),
 		waypoint.Waypointer(&mock))
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -25,8 +25,8 @@ import (
 	commander "code.google.com/p/go-commander"
 	"github.com/golang/glog"
 	"github.com/rochaporto/ezgliding/airfield"
+	"github.com/rochaporto/ezgliding/airspace"
 	"github.com/rochaporto/ezgliding/cli"
-	"github.com/rochaporto/ezgliding/common"
 	"github.com/rochaporto/ezgliding/config"
 	"github.com/rochaporto/ezgliding/context"
 	"github.com/rochaporto/ezgliding/flight"
@@ -47,15 +47,15 @@ func main() {
 		glog.Errorf("Failed to load config :: %v", err)
 		exit(-1)
 	}
-	airspace, err := plugin.NewPlugin(plugin.ID(cfg.Global.Airspacer))
+	aspace, err := plugin.NewPlugin(plugin.ID(cfg.Global.Airspacer))
 	afield, err := plugin.NewPlugin(plugin.ID(cfg.Global.Airfielder))
 	fght, err := plugin.NewPlugin(plugin.ID(cfg.Global.Flighter))
 	wpoint, err := plugin.NewPlugin(plugin.ID(cfg.Global.Waypointer))
-	airspace.Init(cfg)
+	aspace.Init(cfg)
 	afield.Init(cfg)
 	fght.Init(cfg)
 	wpoint.Init(cfg)
-	ctx, err := context.NewContext(cfg, airspace.(common.Airspacer),
+	ctx, err := context.NewContext(cfg, aspace.(airspace.Airspacer),
 		afield.(airfield.Airfielder), fght.(flight.Flighter),
 		wpoint.(waypoint.Waypointer))
 	if err != nil {

--- a/mock/airspace.go
+++ b/mock/airspace.go
@@ -22,19 +22,19 @@ package mock
 import (
 	"time"
 
-	"github.com/rochaporto/ezgliding/common"
+	"github.com/rochaporto/ezgliding/airspace"
 )
 
-// GetAirspace is the mock implementation of common.Airspacer.GetAirspace.
-func (mk *Mock) GetAirspace(regions []string, updatedSince time.Time) ([]common.Airspace, error) {
+// GetAirspace is the mock implementation of airspace.Airspacer.GetAirspace.
+func (mk *Mock) GetAirspace(regions []string, updatedSince time.Time) ([]airspace.Airspace, error) {
 	if mk.GetAirspaceF != nil {
 		return mk.GetAirspaceF(regions, updatedSince)
 	}
-	return []common.Airspace{}, nil
+	return []airspace.Airspace{}, nil
 }
 
-// PutAirspace is the mock implementation of common.Airspacer.PutAirspace.
-func (mk *Mock) PutAirspace(airspace []common.Airspace) error {
+// PutAirspace is the mock implementation of airspace.Airspacer.PutAirspace.
+func (mk *Mock) PutAirspace(airspace []airspace.Airspace) error {
 	if mk.PutAirspaceF != nil {
 		return mk.PutAirspaceF(airspace)
 	}

--- a/mock/airspace_test.go
+++ b/mock/airspace_test.go
@@ -24,15 +24,15 @@ import (
 	"testing"
 	"time"
 
-	"github.com/rochaporto/ezgliding/common"
+	"github.com/rochaporto/ezgliding/airspace"
 )
 
 func TestGetAirspace(t *testing.T) {
-	airspaces := []common.Airspace{
-		common.Airspace{Name: "TestMockAirspace"},
+	airspaces := []airspace.Airspace{
+		airspace.Airspace{Name: "TestMockAirspace"},
 	}
 	mock := Mock{
-		GetAirspaceF: func(regions []string, updatedSince time.Time) ([]common.Airspace, error) {
+		GetAirspaceF: func(regions []string, updatedSince time.Time) ([]airspace.Airspace, error) {
 			return airspaces, nil
 		},
 	}
@@ -57,12 +57,12 @@ func TestGetAirspaceNotImplemented(t *testing.T) {
 }
 
 func TestPutAirspace(t *testing.T) {
-	airspaces := []common.Airspace{
-		common.Airspace{Name: "TestMockAirspace"},
+	airspaces := []airspace.Airspace{
+		airspace.Airspace{Name: "TestMockAirspace"},
 	}
-	var result []common.Airspace
+	var result []airspace.Airspace
 	mock := Mock{
-		PutAirspaceF: func(a []common.Airspace) error {
+		PutAirspaceF: func(a []airspace.Airspace) error {
 			result = a
 			return nil
 		},

--- a/mock/mock.go
+++ b/mock/mock.go
@@ -25,7 +25,7 @@ import (
 	"time"
 
 	"github.com/rochaporto/ezgliding/airfield"
-	"github.com/rochaporto/ezgliding/common"
+	"github.com/rochaporto/ezgliding/airspace"
 	"github.com/rochaporto/ezgliding/config"
 	"github.com/rochaporto/ezgliding/flight"
 	"github.com/rochaporto/ezgliding/waypoint"
@@ -42,8 +42,8 @@ type Mock struct {
 	InitF            func(cfg config.Config) error
 	GetAirfieldF     func(regions []string, updatedSince time.Time) ([]airfield.Airfield, error)
 	PutAirfieldF     func(afield []airfield.Airfield) error
-	GetAirspaceF     func(regions []string, updatedSince time.Time) ([]common.Airspace, error)
-	PutAirspaceF     func(airspace []common.Airspace) error
+	GetAirspaceF     func(regions []string, updatedSince time.Time) ([]airspace.Airspace, error)
+	PutAirspaceF     func(aspace []airspace.Airspace) error
 	GetFlightF       func(regions []string, updatedSince time.Time) ([]flight.Flight, error)
 	GetFlightFromIDF func(startID int, max int) ([]flight.Flight, error)
 	GetFlightByIDF   func(id int) (flight.Flight, error)

--- a/openair/openair_test.go
+++ b/openair/openair_test.go
@@ -20,7 +20,6 @@
 package openair
 
 import (
-	"github.com/rochaporto/ezgliding/common"
 	"image/color"
 	"io"
 	"io/ioutil"
@@ -28,12 +27,14 @@ import (
 	"net/http/httptest"
 	"reflect"
 	"testing"
+
+	"github.com/rochaporto/ezgliding/airspace"
 )
 
 type ParseTest struct {
 	t string
 	c string
-	r []common.Airspace
+	r []airspace.Airspace
 }
 
 var parseTests = []ParseTest{
@@ -52,26 +53,26 @@ DB 45:55:41 N 005:54:39 E,46:10:24 N 005:39:42 E
 DP 46:10:24 N 005:39:42 E
 DC 1.35
 DA 10,270,290`,
-		[]common.Airspace{
-			common.Airspace{
+		[]airspace.Airspace{
+			airspace.Airspace{
 				Class: 'A', Name: "TMA GENEVE partie  2",
 				Floor: "5500FT AMSL", Ceiling: "FL 185",
-				Segments: []common.AirspaceSegment{
-					common.AirspaceSegment{
-						Type: common.Arc, X: "46:03:03 N 005:47:12 E", Clockwise: true,
+				Segments: []airspace.Segment{
+					airspace.Segment{
+						Type: airspace.Arc, X: "46:03:03 N 005:47:12 E", Clockwise: true,
 						Coordinate1: "45:55:41 N 005:54:39 E",
 						Coordinate2: "46:10:24 N 005:39:42 E",
 					},
-					common.AirspaceSegment{
-						Type: common.Polygon, X: "46:03:03 N 005:47:12 E", Clockwise: true,
+					airspace.Segment{
+						Type: airspace.Polygon, X: "46:03:03 N 005:47:12 E", Clockwise: true,
 						Coordinate1: "46:10:24 N 005:39:42 E",
 					},
-					common.AirspaceSegment{
-						Type: common.Circle, X: "46:03:03 N 005:47:12 E", Clockwise: true,
+					airspace.Segment{
+						Type: airspace.Circle, X: "46:03:03 N 005:47:12 E", Clockwise: true,
 						Radius: 1.35,
 					},
-					common.AirspaceSegment{
-						Type: common.Arc, X: "46:03:03 N 005:47:12 E", Clockwise: true,
+					airspace.Segment{
+						Type: airspace.Arc, X: "46:03:03 N 005:47:12 E", Clockwise: true,
 						Radius: 10, AngleStart: 270, AngleEnd: 290,
 					},
 				},
@@ -88,18 +89,18 @@ V X=46:03:03 N 005:47:12 E
 DB 45:55:41 N 005:54:39 E,46:10:24 N 005:39:42 E
 DP 46:10:24 N 005:39:42 E
 *`,
-		[]common.Airspace{
-			common.Airspace{
+		[]airspace.Airspace{
+			airspace.Airspace{
 				Class: 'A', Name: "TMA GENEVE partie  2",
 				Floor: "5500FT AMSL", Ceiling: "FL 185",
-				Segments: []common.AirspaceSegment{
-					common.AirspaceSegment{
-						Type: common.Arc, X: "46:03:03 N 005:47:12 E", Clockwise: true,
+				Segments: []airspace.Segment{
+					airspace.Segment{
+						Type: airspace.Arc, X: "46:03:03 N 005:47:12 E", Clockwise: true,
 						Coordinate1: "45:55:41 N 005:54:39 E",
 						Coordinate2: "46:10:24 N 005:39:42 E",
 					},
-					common.AirspaceSegment{
-						Type: common.Polygon, X: "46:03:03 N 005:47:12 E", Clockwise: true,
+					airspace.Segment{
+						Type: airspace.Polygon, X: "46:03:03 N 005:47:12 E", Clockwise: true,
 						Coordinate1: "46:10:24 N 005:39:42 E",
 					},
 				},
@@ -122,28 +123,28 @@ V D=-
 V X=46:03:03 N 005:47:12 E
 DB 45:55:41 N 005:54:39 E,46:10:24 N 005:39:42 E
 DP 46:10:24 N 005:39:42 E`,
-		[]common.Airspace{
-			common.Airspace{
+		[]airspace.Airspace{
+			airspace.Airspace{
 				Class: 'C', Name: "TMA GENEVE partie  1",
 				Floor: "3500FT AMSL", Ceiling: "FL 195",
-				Segments: []common.AirspaceSegment{
-					common.AirspaceSegment{
-						Type: common.Polygon, Clockwise: false,
+				Segments: []airspace.Segment{
+					airspace.Segment{
+						Type: airspace.Polygon, Clockwise: false,
 						Coordinate1: "46:22:03 N 006:33:04 E",
 					},
 				},
 			},
-			common.Airspace{
+			airspace.Airspace{
 				Class: 'A', Name: "TMA GENEVE partie  2",
 				Floor: "5500FT AMSL", Ceiling: "FL 185",
-				Segments: []common.AirspaceSegment{
-					common.AirspaceSegment{
-						Type: common.Arc, X: "46:03:03 N 005:47:12 E", Clockwise: false,
+				Segments: []airspace.Segment{
+					airspace.Segment{
+						Type: airspace.Arc, X: "46:03:03 N 005:47:12 E", Clockwise: false,
 						Coordinate1: "45:55:41 N 005:54:39 E",
 						Coordinate2: "46:10:24 N 005:39:42 E",
 					},
-					common.AirspaceSegment{
-						Type: common.Polygon, X: "46:03:03 N 005:47:12 E", Clockwise: false,
+					airspace.Segment{
+						Type: airspace.Polygon, X: "46:03:03 N 005:47:12 E", Clockwise: false,
 						Coordinate1: "46:10:24 N 005:39:42 E",
 					},
 				},
@@ -161,18 +162,18 @@ AH FL 195
 AL 3500FT AMSL
 DP 46:22:03 N 006:33:04 E
 `,
-		[]common.Airspace{
-			common.Airspace{
+		[]airspace.Airspace{
+			airspace.Airspace{
 				Class: 'C', Name: "TMA GENEVE partie  1",
 				Floor: "3500FT AMSL", Ceiling: "FL 195",
-				Segments: []common.AirspaceSegment{
-					common.AirspaceSegment{
-						Type: common.Polygon, Clockwise: false,
+				Segments: []airspace.Segment{
+					airspace.Segment{
+						Type: airspace.Polygon, Clockwise: false,
 						Coordinate1: "46:22:03 N 006:33:04 E",
 					},
 				},
-				Pen: common.Pen{
-					Style: common.Solid, Width: 2,
+				Pen: airspace.Pen{
+					Style: airspace.Solid, Width: 2,
 					Color:       color.RGBA64{R: 0, G: 0, B: 255, A: 1.0},
 					InsideColor: color.RGBA64{},
 				},
@@ -247,16 +248,16 @@ func TestFetchEmpty(t *testing.T) {
 }
 
 func TestStyleToAirspace(t *testing.T) {
-	if styleToAirspace(0) != common.Solid {
+	if styleToAirspace(0) != airspace.Solid {
 		t.Errorf("Failed to return proper Solid pen style")
 	}
-	if styleToAirspace(1) != common.Dash {
+	if styleToAirspace(1) != airspace.Dash {
 		t.Errorf("Failed to return proper Dash pen style")
 	}
-	if styleToAirspace(5) != common.None {
+	if styleToAirspace(5) != airspace.None {
 		t.Errorf("Failed to return proper None pen style")
 	}
-	if styleToAirspace(-1) != common.None {
+	if styleToAirspace(-1) != airspace.None {
 		t.Errorf("Failed to return proper unknown pen style")
 	}
 }

--- a/soaringweb/soaringweb.go
+++ b/soaringweb/soaringweb.go
@@ -34,7 +34,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/rochaporto/ezgliding/common"
+	"github.com/rochaporto/ezgliding/airspace"
 	"github.com/rochaporto/ezgliding/config"
 	"github.com/rochaporto/ezgliding/openair"
 	"golang.org/x/net/html"
@@ -95,8 +95,8 @@ func (sw *SoaringWeb) Init(cfg config.Config) error {
 }
 
 // GetAirspace follows Airspace.GetAirspace().
-func (sw *SoaringWeb) GetAirspace(regions []string, updatedSince time.Time) ([]common.Airspace, error) {
-	var result []common.Airspace
+func (sw *SoaringWeb) GetAirspace(regions []string, updatedSince time.Time) ([]airspace.Airspace, error) {
+	var result []airspace.Airspace
 
 	releases, err := sw.list(sw.BaseURL, regions)
 	if err != nil {
@@ -105,7 +105,7 @@ func (sw *SoaringWeb) GetAirspace(regions []string, updatedSince time.Time) ([]c
 	for r := range releases {
 		release := releases[r]
 		if release.Date.After(updatedSince) {
-			var airspaces []common.Airspace
+			var airspaces []airspace.Airspace
 			airspaces, err = openair.Fetch(release.Location)
 			if err != nil {
 				// retry by prefixing the base url
@@ -122,7 +122,7 @@ func (sw *SoaringWeb) GetAirspace(regions []string, updatedSince time.Time) ([]c
 }
 
 // PutAirspace follows Airspacer.PutAirspace().
-func (sw *SoaringWeb) PutAirspace(airspace []common.Airspace) error {
+func (sw *SoaringWeb) PutAirspace(airspace []airspace.Airspace) error {
 	return nil
 }
 

--- a/soaringweb/soaringweb_test.go
+++ b/soaringweb/soaringweb_test.go
@@ -20,8 +20,6 @@
 package soaringweb
 
 import (
-	"github.com/rochaporto/ezgliding/common"
-	"github.com/rochaporto/ezgliding/config"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -29,6 +27,9 @@ import (
 	"reflect"
 	"testing"
 	"time"
+
+	"github.com/rochaporto/ezgliding/airspace"
+	"github.com/rochaporto/ezgliding/config"
 )
 
 type ParseTest struct {
@@ -205,7 +206,7 @@ type GetAirspaceTest struct {
 	b  string
 	rg string
 	d  time.Time
-	r  []common.Airspace
+	r  []airspace.Airspace
 }
 
 var getAirspaceTests = []GetAirspaceTest{
@@ -213,40 +214,40 @@ var getAirspaceTests = []GetAirspaceTest{
 		"./t",
 		"FR",
 		time.Time{},
-		[]common.Airspace{
-			common.Airspace{
+		[]airspace.Airspace{
+			airspace.Airspace{
 				Class: 'C', Name: "CTR Annecy 118.2",
 				Floor: "SFC", Ceiling: "3500FT AMSL",
-				Segments: []common.AirspaceSegment{
-					common.AirspaceSegment{
-						Type: common.Polygon, Coordinate1: "46:02:56 N 006:09:33 E",
+				Segments: []airspace.Segment{
+					airspace.Segment{
+						Type: airspace.Polygon, Coordinate1: "46:02:56 N 006:09:33 E",
 					},
-					common.AirspaceSegment{
-						Type: common.Polygon, Coordinate1: "45:59:06 N 006:14:32 E",
+					airspace.Segment{
+						Type: airspace.Polygon, Coordinate1: "45:59:06 N 006:14:32 E",
 					},
-					common.AirspaceSegment{
-						Type: common.Polygon, Coordinate1: "45:48:36 N 006:02:30 E",
+					airspace.Segment{
+						Type: airspace.Polygon, Coordinate1: "45:48:36 N 006:02:30 E",
 					},
-					common.AirspaceSegment{
-						Type: common.Arc, X: "45:55:40 N 006:05:41 E", Clockwise: false,
+					airspace.Segment{
+						Type: airspace.Arc, X: "45:55:40 N 006:05:41 E", Clockwise: false,
 						Coordinate1: "45:48:36 N 006:02:30 E", Coordinate2: "45:55:57 N 005:55:05 E",
 					},
-					common.AirspaceSegment{
-						Type: common.Polygon, X: "45:55:40 N 006:05:41 E",
+					airspace.Segment{
+						Type: airspace.Polygon, X: "45:55:40 N 006:05:41 E",
 						Coordinate1: "45:55:57 N 005:55:05 E",
 					},
 				},
 			},
-			common.Airspace{
+			airspace.Airspace{
 				Class: 'C', Name: "Geneve9 C 126.35",
 				Floor: "FL115", Ceiling: "FL195",
-				Segments: []common.AirspaceSegment{
-					common.AirspaceSegment{
-						Type: common.Polygon, Clockwise: false,
+				Segments: []airspace.Segment{
+					airspace.Segment{
+						Type: airspace.Polygon, Clockwise: false,
 						Coordinate1: "45:52:25 N 006:07:45 E",
 					},
-					common.AirspaceSegment{
-						Type: common.Polygon, Clockwise: false,
+					airspace.Segment{
+						Type: airspace.Polygon, Clockwise: false,
 						Coordinate1: "45:50:38 N 006:06:05 E",
 					},
 				},
@@ -257,16 +258,16 @@ var getAirspaceTests = []GetAirspaceTest{
 		"./t",
 		"MP",
 		time.Date(2014, time.August, 25, 0, 0, 0, 0, time.UTC),
-		[]common.Airspace{
-			common.Airspace{
+		[]airspace.Airspace{
+			airspace.Airspace{
 				Class: 'C', Name: "CTR Chambery2 118.3",
 				Floor: "1160FT AMSL", Ceiling: "3500FT AMSL",
-				Segments: []common.AirspaceSegment{
-					common.AirspaceSegment{
-						Type: common.Polygon, Coordinate1: "45:39:35 N 005:55:48 E",
+				Segments: []airspace.Segment{
+					airspace.Segment{
+						Type: airspace.Polygon, Coordinate1: "45:39:35 N 005:55:48 E",
 					},
-					common.AirspaceSegment{
-						Type: common.Polygon, Coordinate1: "45:36:28 N 005:56:03 E",
+					airspace.Segment{
+						Type: airspace.Polygon, Coordinate1: "45:36:28 N 005:56:03 E",
 					},
 				},
 			},
@@ -276,16 +277,16 @@ var getAirspaceTests = []GetAirspaceTest{
 		"./t/wb",
 		"PT",
 		time.Time{},
-		[]common.Airspace{
-			common.Airspace{
+		[]airspace.Airspace{
+			airspace.Airspace{
 				Class: 'C', Name: "CTR Chambery2 118.3",
 				Floor: "1160FT AMSL", Ceiling: "3500FT AMSL",
-				Segments: []common.AirspaceSegment{
-					common.AirspaceSegment{
-						Type: common.Polygon, Coordinate1: "45:39:35 N 005:55:48 E",
+				Segments: []airspace.Segment{
+					airspace.Segment{
+						Type: airspace.Polygon, Coordinate1: "45:39:35 N 005:55:48 E",
 					},
-					common.AirspaceSegment{
-						Type: common.Polygon, Coordinate1: "45:36:28 N 005:56:03 E",
+					airspace.Segment{
+						Type: airspace.Polygon, Coordinate1: "45:36:28 N 005:56:03 E",
 					},
 				},
 			},
@@ -305,7 +306,7 @@ func TestGetAirspace(t *testing.T) {
 			t.Errorf("Failed to initialize plugin :: %v", err)
 		}
 
-		var airspaces []common.Airspace
+		var airspaces []airspace.Airspace
 		airspaces, err = plugin.GetAirspace([]string{test.rg}, test.d)
 		if err != nil {
 			t.Errorf("Failed to get airspace :: %v", err)
@@ -316,11 +317,11 @@ func TestGetAirspace(t *testing.T) {
 		}
 
 		for i := range airspaces {
-			var airspace = airspaces[i]
+			var aspace = airspaces[i]
 			var expected = test.r[i]
-			airspace.Pen = common.Pen{}
-			if !reflect.DeepEqual(airspace, expected) {
-				t.Errorf("Got wrong airspace. %v instead of %v", airspace, expected)
+			aspace.Pen = airspace.Pen{}
+			if !reflect.DeepEqual(aspace, expected) {
+				t.Errorf("Got wrong airspace. %v instead of %v", aspace, expected)
 			}
 		}
 	}
@@ -335,7 +336,7 @@ func TestGetAirspaceEmptyRegion(t *testing.T) {
 		t.Errorf("Failed to initialize plugin :: %v", err)
 	}
 
-	var airspaces []common.Airspace
+	var airspaces []airspace.Airspace
 	airspaces, err = plugin.GetAirspace([]string{}, time.Time{})
 	if err != nil {
 		t.Errorf("Got error when retrieving airspace with empty regions :: %v", err)

--- a/util/spatial.go
+++ b/util/spatial.go
@@ -111,7 +111,7 @@ func waypoint2GeoJSON(waypoints []waypoint.Waypoint) []*geojson.Feature {
 
 // GeoJSON2Struct returns airfield, waypoint, etc objects from the given GeoJSON.
 // The resulting array contains distinct types (airfield.Airfield, waypoint.Waypoint,
-// common.Airspace, ...) and the unmarshaling is done with the same rules as
+// airspace.Airspace, ...) and the unmarshaling is done with the same rules as
 // described in Struct2GeoJSON.
 func GeoJSON2Struct(json string) ([]interface{}, error) {
 	result := []interface{}{}


### PR DESCRIPTION
adds a new airspace pkg holding all airspace related interfaces and
types/structs. this is part of the refactor effort to get rid of common.

Implements #69.