### PR TITLE
refactor airfield into its own pkg (was common).

### DIFF
--- a/airfield/airfield.go
+++ b/airfield/airfield.go
@@ -17,7 +17,8 @@
 //
 // Author: Ricardo Rocha <rocha.porto@gmail.com>
 
-package common
+// Package airfield holds all airfield functionality and structures.
+package airfield
 
 import (
 	"time"

--- a/cli/airfield.go
+++ b/cli/airfield.go
@@ -28,7 +28,7 @@ import (
 
 	commander "code.google.com/p/go-commander"
 	"github.com/golang/glog"
-	"github.com/rochaporto/ezgliding/common"
+	"github.com/rochaporto/ezgliding/airfield"
 	"github.com/rochaporto/ezgliding/context"
 	"github.com/rochaporto/ezgliding/plugin"
 	"github.com/rochaporto/ezgliding/util"
@@ -49,7 +49,7 @@ Gets available airfield information according to the given parameters
 func runAirfieldGet(cmd *commander.Command, args []string) {
 	var err error
 	ctx := context.Ctx
-	airfield := ctx.Airfield
+	afield := ctx.Airfield
 
 	tafter := time.Time{}
 	if *after != "" {
@@ -59,7 +59,7 @@ func runAirfieldGet(cmd *commander.Command, args []string) {
 			return
 		}
 	}
-	airfields, err := airfield.(common.Airfielder).GetAirfield(strings.Split(*region, ","), tafter)
+	airfields, err := afield.(airfield.Airfielder).GetAirfield(strings.Split(*region, ","), tafter)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to get airfield :: %v\n", err)
 		return
@@ -100,8 +100,8 @@ func runAirfieldPut(cmd *commander.Command, args []string) {
 		fmt.Fprintf(os.Stderr, "failed to init plugin '%v' :: %v\n", pluginID, err)
 		return
 	}
-	airfield := ctx.Airfield
-	airfields, err := airfield.(common.Airfielder).GetAirfield(strings.Split(*region, ","), time.Time{})
+	afield := ctx.Airfield
+	airfields, err := afield.(airfield.Airfielder).GetAirfield(strings.Split(*region, ","), time.Time{})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to get airfield :: %v\n", err)
 		return
@@ -109,7 +109,7 @@ func runAirfieldPut(cmd *commander.Command, args []string) {
 	glog.V(5).Infof("putting %v airfields", len(airfields))
 	glog.V(20).Infof("%v", airfields)
 	if len(airfields) > 0 {
-		err = destPlugin.(common.Airfielder).PutAirfield(airfields)
+		err = destPlugin.(airfield.Airfielder).PutAirfield(airfields)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "failed to put airfields :: %v\n", err)
 			return

--- a/cli/airfield_test.go
+++ b/cli/airfield_test.go
@@ -25,7 +25,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/rochaporto/ezgliding/common"
+	"github.com/rochaporto/ezgliding/airfield"
 	"github.com/rochaporto/ezgliding/config"
 	"github.com/rochaporto/ezgliding/context"
 	"github.com/rochaporto/ezgliding/mock"
@@ -38,28 +38,28 @@ import (
 func ExampleAirfieldGet() {
 	ctx := context.Context{
 		Airfield: &mock.Mock{
-			GetAirfieldF: func(regions []string, updatedSince time.Time) ([]common.Airfield, error) {
-				airfields := []common.Airfield{
-					common.Airfield{
+			GetAirfieldF: func(regions []string, updatedSince time.Time) ([]airfield.Airfield, error) {
+				airfields := []airfield.Airfield{
+					airfield.Airfield{
 						ID: "MockID1", ShortName: "MockShortName",
 						Name: "MockName", Region: "FR", ICAO: "AAAA", Flags: 0,
 						Catalog: 11, Length: 1000, Elevation: 2000, Runway: "32R",
 						Frequency: 123.45, Latitude: 32.533, Longitude: 100.376,
 						Update: time.Date(2014, 02, 02, 0, 0, 0, 0, time.UTC)},
-					common.Airfield{
+					airfield.Airfield{
 						ID: "MockID2", ShortName: "MockShortName",
 						Name: "MockName", Region: "CH", ICAO: "AAAA", Flags: 0,
 						Catalog: 11, Length: 1000, Elevation: 2000, Runway: "32R",
 						Frequency: 123.45, Latitude: 32.533, Longitude: 100.376,
 						Update: time.Date(2014, 02, 02, 0, 0, 0, 0, time.UTC)},
-					common.Airfield{
+					airfield.Airfield{
 						ID: "MockID3", ShortName: "MockShortName",
 						Name: "MockName", Region: "CH", ICAO: "AAAA", Flags: 0,
 						Catalog: 11, Length: 1000, Elevation: 2000, Runway: "32R",
 						Frequency: 123.45, Latitude: 32.533, Longitude: 100.376,
 						Update: time.Date(2014, 02, 03, 0, 0, 0, 0, time.UTC)},
 				}
-				result := []common.Airfield{}
+				result := []airfield.Airfield{}
 				for _, airfield := range airfields {
 					b := false
 					for _, r := range regions {
@@ -87,7 +87,7 @@ func ExampleAirfieldGet() {
 func TestAirfieldGetFailed(t *testing.T) {
 	ctx := context.Context{
 		Airfield: &mock.Mock{
-			GetAirfieldF: func(regions []string, updatedSince time.Time) ([]common.Airfield, error) {
+			GetAirfieldF: func(regions []string, updatedSince time.Time) ([]airfield.Airfield, error) {
 				return nil, errors.New("mock testing get airfield failed")
 			},
 		},
@@ -101,7 +101,7 @@ func TestAirfieldGetFailed(t *testing.T) {
 func TestAirfieldGetBadAfter(t *testing.T) {
 	ctx := context.Context{
 		Airfield: &mock.Mock{
-			GetAirfieldF: func(regions []string, updatedSince time.Time) ([]common.Airfield, error) {
+			GetAirfieldF: func(regions []string, updatedSince time.Time) ([]airfield.Airfield, error) {
 				return nil, nil
 			},
 		},
@@ -117,9 +117,9 @@ func TestAirfieldGetBadAfter(t *testing.T) {
 func ExampleAirfieldPut() {
 	ctx := context.Context{
 		Airfield: &mock.Mock{
-			GetAirfieldF: func(regions []string, updatedSince time.Time) ([]common.Airfield, error) {
-				return []common.Airfield{
-					common.Airfield{ID: "MockID", ShortName: "MockShortName", Name: "MockName",
+			GetAirfieldF: func(regions []string, updatedSince time.Time) ([]airfield.Airfield, error) {
+				return []airfield.Airfield{
+					airfield.Airfield{ID: "MockID", ShortName: "MockShortName", Name: "MockName",
 						Region: "FR", ICAO: "AAAA", Flags: 0, Catalog: 11, Length: 1000, Elevation: 2000,
 						Runway: "32R", Frequency: 123.45, Latitude: 32.533, Longitude: 100.376,
 						Update: time.Time{}},
@@ -136,7 +136,7 @@ func ExampleAirfieldPut() {
 func TestAirfieldPutFailed(t *testing.T) {
 	err := plugin.Register(plugin.ID("afputfailed"), plugin.Pluginer(
 		&mock.Mock{
-			PutAirfieldF: func(airfields []common.Airfield) error {
+			PutAirfieldF: func(airfields []airfield.Airfield) error {
 				return errors.New("mock testing put airfield failed")
 			},
 		}))
@@ -145,8 +145,8 @@ func TestAirfieldPutFailed(t *testing.T) {
 	}
 	ctx := context.Context{
 		Airfield: &mock.Mock{
-			GetAirfieldF: func(regions []string, updatedSince time.Time) ([]common.Airfield, error) {
-				return []common.Airfield{common.Airfield{}}, nil
+			GetAirfieldF: func(regions []string, updatedSince time.Time) ([]airfield.Airfield, error) {
+				return []airfield.Airfield{airfield.Airfield{}}, nil
 			},
 		},
 	}
@@ -157,7 +157,7 @@ func TestAirfieldPutFailed(t *testing.T) {
 func TestAirfieldPutBadGet(t *testing.T) {
 	ctx := context.Context{
 		Airfield: &mock.Mock{
-			GetAirfieldF: func(regions []string, updatedSince time.Time) ([]common.Airfield, error) {
+			GetAirfieldF: func(regions []string, updatedSince time.Time) ([]airfield.Airfield, error) {
 				return nil, errors.New("mock testing get airfield failed")
 			},
 		},
@@ -186,8 +186,8 @@ func TestAirfieldPutFailInit(t *testing.T) {
 	}
 	ctx := context.Context{
 		Airfield: &mock.Mock{
-			GetAirfieldF: func(regions []string, updatedSince time.Time) ([]common.Airfield, error) {
-				return []common.Airfield{common.Airfield{}}, nil
+			GetAirfieldF: func(regions []string, updatedSince time.Time) ([]airfield.Airfield, error) {
+				return []airfield.Airfield{airfield.Airfield{}}, nil
 			},
 		},
 	}

--- a/cli/web_test.go
+++ b/cli/web_test.go
@@ -23,7 +23,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/rochaporto/ezgliding/common"
+	"github.com/rochaporto/ezgliding/airfield"
 	"github.com/rochaporto/ezgliding/config"
 	"github.com/rochaporto/ezgliding/context"
 	"github.com/rochaporto/ezgliding/mock"
@@ -35,9 +35,9 @@ func ExampleWeb() {
 	cfg.Web.Port = 7777
 	ctx := context.Context{
 		Airfield: &mock.Mock{
-			GetAirfieldF: func(regions []string, updatedSince time.Time) ([]common.Airfield, error) {
-				return []common.Airfield{
-					common.Airfield{ID: "MockID", ShortName: "MockShortName", Name: "MockName",
+			GetAirfieldF: func(regions []string, updatedSince time.Time) ([]airfield.Airfield, error) {
+				return []airfield.Airfield{
+					airfield.Airfield{ID: "MockID", ShortName: "MockShortName", Name: "MockName",
 						Region: "FR", ICAO: "AAAA", Flags: 0, Catalog: 11, Length: 1000, Elevation: 2000,
 						Runway: "32R", Frequency: 123.45, Latitude: 32.533, Longitude: 100.376},
 				}, nil

--- a/context/context.go
+++ b/context/context.go
@@ -26,6 +26,7 @@
 package context
 
 import (
+	"github.com/rochaporto/ezgliding/airfield"
 	"github.com/rochaporto/ezgliding/common"
 	"github.com/rochaporto/ezgliding/config"
 	"github.com/rochaporto/ezgliding/flight"
@@ -42,13 +43,13 @@ var Ctx Context
 type Context struct {
 	Config   config.Config
 	Airspace common.Airspacer
-	Airfield common.Airfielder
+	Airfield airfield.Airfielder
 	Flight   flight.Flighter
 	Waypoint common.Waypointer
 }
 
 // NewContext returns a new Context object.
-func NewContext(cfg config.Config, airspace common.Airspacer, airfield common.Airfielder,
+func NewContext(cfg config.Config, airspace common.Airspacer, airfield airfield.Airfielder,
 	flight flight.Flighter, waypoint common.Waypointer) (Context, error) {
 	return Context{Config: cfg, Airspace: airspace, Airfield: airfield,
 		Flight: flight, Waypoint: waypoint}, nil

--- a/context/context_test.go
+++ b/context/context_test.go
@@ -22,6 +22,7 @@ package context
 import (
 	"testing"
 
+	"github.com/rochaporto/ezgliding/airfield"
 	"github.com/rochaporto/ezgliding/common"
 	"github.com/rochaporto/ezgliding/config"
 	"github.com/rochaporto/ezgliding/flight"
@@ -31,7 +32,7 @@ import (
 func TestNewContext(t *testing.T) {
 	mock := mock.Mock{}
 	_, err := NewContext(config.Config{}, common.Airspacer(&mock),
-		common.Airfielder(&mock), flight.Flighter(&mock),
+		airfield.Airfielder(&mock), flight.Flighter(&mock),
 		common.Waypointer(&mock))
 	if err != nil {
 		t.Errorf("Failed to get new context :: %v", err)

--- a/fusiontables/airfield.go
+++ b/fusiontables/airfield.go
@@ -25,12 +25,12 @@ import (
 	"time"
 
 	"github.com/golang/glog"
-	"github.com/rochaporto/ezgliding/common"
+	"github.com/rochaporto/ezgliding/airfield"
 	"github.com/rochaporto/ezgliding/util"
 )
 
 // GetAirfield follows common.GetAirfield().
-func (ft *FusionTables) GetAirfield(regions []string, updatedSince time.Time) ([]common.Airfield, error) {
+func (ft *FusionTables) GetAirfield(regions []string, updatedSince time.Time) ([]airfield.Airfield, error) {
 	glog.V(10).Infof("GetAirfield with regions %v and updatedSince %v", regions, updatedSince)
 
 	var qry string
@@ -47,12 +47,12 @@ func (ft *FusionTables) GetAirfield(regions []string, updatedSince time.Time) ([
 	}
 	glog.V(20).Infof("unparsed response :: %v", resp)
 
-	r, err := util.CSV2Struct(resp, reflect.ValueOf([]common.Airfield{}).Type(),
-		reflect.ValueOf(common.Airfield{}).Type())
+	r, err := util.CSV2Struct(resp, reflect.ValueOf([]airfield.Airfield{}).Type(),
+		reflect.ValueOf(airfield.Airfield{}).Type())
 	if err != nil {
 		return nil, err
 	}
-	result := r.Interface().([]common.Airfield)
+	result := r.Interface().([]airfield.Airfield)
 
 	glog.V(5).Infof("request %v returned %v results", qry, len(result))
 
@@ -60,7 +60,7 @@ func (ft *FusionTables) GetAirfield(regions []string, updatedSince time.Time) ([
 }
 
 // PutAirfield follows common.PutAirfield().
-func (ft *FusionTables) PutAirfield(airfields []common.Airfield) error {
+func (ft *FusionTables) PutAirfield(airfields []airfield.Airfield) error {
 	csv := util.Struct2CSV(airfields)
 	resp, err := ft.doImport(csv, ft.AirfieldTableID)
 	if err != nil {

--- a/fusiontables/airfield_test.go
+++ b/fusiontables/airfield_test.go
@@ -27,7 +27,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/rochaporto/ezgliding/common"
+	"github.com/rochaporto/ezgliding/airfield"
 	"github.com/rochaporto/ezgliding/config"
 )
 
@@ -36,7 +36,7 @@ type GetAirfieldTest struct {
 	rg  []string
 	tm  time.Time
 	rp  string
-	rs  []common.Airfield
+	rs  []airfield.Airfield
 	err bool
 }
 
@@ -49,8 +49,8 @@ var getGetAirfieldTests = []GetAirfieldTest{
 ID,ShortName,Name,Region,RLICAO,Flags,Catalog,Length,Elevation,Runway,Frequency,Latitude,Longitude
 HABER,HABER,HABERE POC69,FR,,1032,0,0,1113,0119,122.5,46.270,6.463
 `,
-		[]common.Airfield{
-			common.Airfield{ID: "HABER", ShortName: "HABER", Name: "HABERE POC69",
+		[]airfield.Airfield{
+			airfield.Airfield{ID: "HABER", ShortName: "HABER", Name: "HABERE POC69",
 				Region: "FR", ICAO: "", Flags: 1032, Catalog: 0, Length: 0, Elevation: 1113,
 				Runway: "0119", Frequency: 122.5, Latitude: 46.270, Longitude: 6.463},
 		},
@@ -64,7 +64,7 @@ HABER,HABER,HABERE POC69,FR,,1032,0,0,1113,0119,122.5,46.270,6.463
 ID,ShortName,Name,Region,ICAO,Flags,Catalog,Length,Elevation,Runway,Frequency,Latitude,Longitude
 HABER,HABER,HABERE POC69,FR,,1032,0,0,1113,0119,122.5,46.270,6.463,a
 `,
-		[]common.Airfield{common.Airfield{}},
+		[]airfield.Airfield{airfield.Airfield{}},
 		true,
 	},
 	{
@@ -75,8 +75,8 @@ HABER,HABER,HABERE POC69,FR,,1032,0,0,1113,0119,122.5,46.270,6.463,a
 ID,ShortName,Name,Region,ICAO,Flags,Catalog,Length,Elevation,Runway,Frequency,Latitude,Longitude
 HABER,HABER,HABERE POC69,FR,,1032,0,0,1113,0119,122.5,46.270,6.463
 `,
-		[]common.Airfield{
-			common.Airfield{ID: "HABER", ShortName: "HABER", Name: "HABERE POC69",
+		[]airfield.Airfield{
+			airfield.Airfield{ID: "HABER", ShortName: "HABER", Name: "HABERE POC69",
 				Region: "FR", ICAO: "", Flags: 1032, Catalog: 0, Length: 0, Elevation: 1113,
 				Runway: "0119", Frequency: 122.5, Latitude: 46.270, Longitude: 6.463},
 		},
@@ -151,7 +151,7 @@ func TestGetAirfieldWithMalformedURL(t *testing.T) {
 
 type PutAirfieldTest struct {
 	t   string
-	in  []common.Airfield
+	in  []airfield.Airfield
 	csv string
 	err bool
 }
@@ -159,8 +159,8 @@ type PutAirfieldTest struct {
 var putAirfieldTests = []PutAirfieldTest{
 	{
 		"simple update",
-		[]common.Airfield{
-			common.Airfield{ID: "HABER", ShortName: "HABER", Name: "HABERE POC69",
+		[]airfield.Airfield{
+			airfield.Airfield{ID: "HABER", ShortName: "HABER", Name: "HABERE POC69",
 				Region: "FR", ICAO: "", Flags: 1032, Catalog: 0, Length: 0, Elevation: 1113,
 				Runway: "0119", Frequency: 122.5, Latitude: 46.270, Longitude: 6.463,
 				Update: time.Time{}},
@@ -172,8 +172,8 @@ HABER,HABER,HABERE POC69,FR,,1032,0,0,1113,0119,122.5,46.27,6.463,0001-01-01 00:
 	},
 	{
 		"simple failure",
-		[]common.Airfield{
-			common.Airfield{ID: "HABER", ShortName: "HABER", Name: "HABERE POC69",
+		[]airfield.Airfield{
+			airfield.Airfield{ID: "HABER", ShortName: "HABER", Name: "HABERE POC69",
 				Region: "FR", ICAO: "", Flags: 1032, Catalog: 0, Length: 0, Elevation: 1113,
 				Runway: "0119", Frequency: 122.5, Latitude: 46.270, Longitude: 6.463,
 				Update: time.Time{}},
@@ -225,7 +225,7 @@ func TestPutAirfieldWithMissingLocation(t *testing.T) {
 	if err != nil {
 		t.Errorf("Failed to initialize plugin :: %v", err)
 	}
-	err = plugin.PutAirfield([]common.Airfield{})
+	err = plugin.PutAirfield([]airfield.Airfield{})
 	if err == nil {
 		t.Errorf("expected error but was successful")
 	}
@@ -240,7 +240,7 @@ func TestPutAirfieldWithMalformedURL(t *testing.T) {
 	if err != nil {
 		t.Errorf("Failed to initialize plugin :: %v", err)
 	}
-	err = plugin.PutAirfield([]common.Airfield{})
+	err = plugin.PutAirfield([]airfield.Airfield{})
 	if err == nil {
 		t.Errorf("expected error but was successful")
 	}
@@ -260,8 +260,8 @@ func TestPutAirfieldWithBadStatus(t *testing.T) {
 	if err != nil {
 		t.Errorf("failed to initialize plugin :: %v", err)
 	}
-	err = plugin.PutAirfield([]common.Airfield{
-		common.Airfield{ID: "aHABER", ShortName: "HABER", Name: "HABERE POC69",
+	err = plugin.PutAirfield([]airfield.Airfield{
+		airfield.Airfield{ID: "aHABER", ShortName: "HABER", Name: "HABERE POC69",
 			Region: "FR", ICAO: "", Flags: 1032, Catalog: 0, Length: 0, Elevation: 1113,
 			Runway: "0119", Frequency: 122.5, Latitude: 46.270, Longitude: 6.463},
 	})

--- a/main.go
+++ b/main.go
@@ -24,6 +24,7 @@ import (
 
 	commander "code.google.com/p/go-commander"
 	"github.com/golang/glog"
+	"github.com/rochaporto/ezgliding/airfield"
 	"github.com/rochaporto/ezgliding/cli"
 	"github.com/rochaporto/ezgliding/common"
 	"github.com/rochaporto/ezgliding/config"
@@ -46,15 +47,15 @@ func main() {
 		exit(-1)
 	}
 	airspace, err := plugin.NewPlugin(plugin.ID(cfg.Global.Airspacer))
-	airfield, err := plugin.NewPlugin(plugin.ID(cfg.Global.Airfielder))
+	afield, err := plugin.NewPlugin(plugin.ID(cfg.Global.Airfielder))
 	fght, err := plugin.NewPlugin(plugin.ID(cfg.Global.Flighter))
 	waypoint, err := plugin.NewPlugin(plugin.ID(cfg.Global.Waypointer))
 	airspace.Init(cfg)
-	airfield.Init(cfg)
+	afield.Init(cfg)
 	fght.Init(cfg)
 	waypoint.Init(cfg)
 	ctx, err := context.NewContext(cfg, airspace.(common.Airspacer),
-		airfield.(common.Airfielder), fght.(flight.Flighter),
+		afield.(airfield.Airfielder), fght.(flight.Flighter),
 		waypoint.(common.Waypointer))
 	if err != nil {
 		glog.Errorf("Failed to create context object :: %v", err)

--- a/mock/airfield.go
+++ b/mock/airfield.go
@@ -22,19 +22,19 @@ package mock
 import (
 	"time"
 
-	"github.com/rochaporto/ezgliding/common"
+	"github.com/rochaporto/ezgliding/airfield"
 )
 
-// GetAirfield is the mock implementation of common.Airfielder.GetAirfield.
-func (mk *Mock) GetAirfield(regions []string, updatedSince time.Time) ([]common.Airfield, error) {
+// GetAirfield is the mock implementation of airfield.Airfielder.GetAirfield.
+func (mk *Mock) GetAirfield(regions []string, updatedSince time.Time) ([]airfield.Airfield, error) {
 	if mk.GetAirfieldF != nil {
 		return mk.GetAirfieldF(regions, updatedSince)
 	}
-	return []common.Airfield{}, nil
+	return []airfield.Airfield{}, nil
 }
 
-// PutAirfield is the mock implementation of common.Airfielder.PutAirfield.
-func (mk *Mock) PutAirfield(airfield []common.Airfield) error {
+// PutAirfield is the mock implementation of airfield.Airfielder.PutAirfield.
+func (mk *Mock) PutAirfield(airfield []airfield.Airfield) error {
 	if mk.PutAirfieldF != nil {
 		return mk.PutAirfieldF(airfield)
 	}

--- a/mock/airfield_test.go
+++ b/mock/airfield_test.go
@@ -24,15 +24,15 @@ import (
 	"testing"
 	"time"
 
-	"github.com/rochaporto/ezgliding/common"
+	"github.com/rochaporto/ezgliding/airfield"
 )
 
 func TestGetAirfield(t *testing.T) {
-	airfields := []common.Airfield{
-		common.Airfield{Name: "TestMockAirfield"},
+	airfields := []airfield.Airfield{
+		airfield.Airfield{Name: "TestMockAirfield"},
 	}
 	mock := Mock{
-		GetAirfieldF: func(regions []string, updatedSince time.Time) ([]common.Airfield, error) {
+		GetAirfieldF: func(regions []string, updatedSince time.Time) ([]airfield.Airfield, error) {
 			return airfields, nil
 		},
 	}
@@ -57,12 +57,12 @@ func TestGetAirfieldNotImplemented(t *testing.T) {
 }
 
 func TestPutAirfield(t *testing.T) {
-	airfields := []common.Airfield{
-		common.Airfield{Name: "TestMockAirfield"},
+	airfields := []airfield.Airfield{
+		airfield.Airfield{Name: "TestMockAirfield"},
 	}
-	var result []common.Airfield
+	var result []airfield.Airfield
 	mock := Mock{
-		PutAirfieldF: func(a []common.Airfield) error {
+		PutAirfieldF: func(a []airfield.Airfield) error {
 			result = a
 			return nil
 		},

--- a/mock/mock.go
+++ b/mock/mock.go
@@ -24,6 +24,7 @@ package mock
 import (
 	"time"
 
+	"github.com/rochaporto/ezgliding/airfield"
 	"github.com/rochaporto/ezgliding/common"
 	"github.com/rochaporto/ezgliding/config"
 	"github.com/rochaporto/ezgliding/flight"
@@ -38,8 +39,8 @@ const (
 // Use the struct fields to provide the function implementations.
 type Mock struct {
 	InitF            func(cfg config.Config) error
-	GetAirfieldF     func(regions []string, updatedSince time.Time) ([]common.Airfield, error)
-	PutAirfieldF     func(airfield []common.Airfield) error
+	GetAirfieldF     func(regions []string, updatedSince time.Time) ([]airfield.Airfield, error)
+	PutAirfieldF     func(afield []airfield.Airfield) error
 	GetAirspaceF     func(regions []string, updatedSince time.Time) ([]common.Airspace, error)
 	PutAirspaceF     func(airspace []common.Airspace) error
 	GetFlightF       func(regions []string, updatedSince time.Time) ([]flight.Flight, error)

--- a/util/csv_test.go
+++ b/util/csv_test.go
@@ -23,13 +23,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/rochaporto/ezgliding/common"
+	"github.com/rochaporto/ezgliding/airfield"
 )
 
 type CSV2AirfieldTest struct {
 	t   string
 	in  string
-	r   []common.Airfield
+	r   []airfield.Airfield
 	err bool
 }
 
@@ -40,8 +40,8 @@ var csv2AirfieldTests = []CSV2AirfieldTest{
 ID,ShortName,Name,Region,ICAO,Flags,Catalog,Length,Elevation,Runway,Frequency,Latitude,Longitude,Update
 HABER,HABER,HABERE POC69,FR,,1032,0,0,1113,0119,122.5,46.270,6.463,0001-01-01 00:00:00 +0000 UTC
 `,
-		[]common.Airfield{
-			common.Airfield{ID: "HABER", ShortName: "HABER", Name: "HABERE POC69",
+		[]airfield.Airfield{
+			airfield.Airfield{ID: "HABER", ShortName: "HABER", Name: "HABERE POC69",
 				Region: "FR", ICAO: "", Flags: 1032, Catalog: 0, Length: 0, Elevation: 1113,
 				Runway: "0119", Frequency: 122.5, Latitude: 46.270, Longitude: 6.463,
 				Update: time.Time{}},
@@ -55,12 +55,12 @@ ID,ShortName,Name,Region,ICAO,Flags,Catalog,Length,Elevation,Runway,Frequency,La
 LSGG,GENEV,GENEVE COINTR,CH,LSGG,64,0,3880,430,0523,118.7,46.238,6.109,0001-01-01 00:00:00 +0000 UTC
 LSGB,BEX,BEX,CH,LSGB,1024,0,0,399,1533,122.15,46.258,6.986,0001-01-01 00:00:00 +0000 UTC
 `,
-		[]common.Airfield{
-			common.Airfield{ID: "LSGG", ShortName: "GENEV", Name: "GENEVE COINTR",
+		[]airfield.Airfield{
+			airfield.Airfield{ID: "LSGG", ShortName: "GENEV", Name: "GENEVE COINTR",
 				Region: "CH", ICAO: "LSGG", Flags: 64, Catalog: 0, Length: 3880, Elevation: 430,
 				Runway: "0523", Frequency: 118.7, Latitude: 46.238, Longitude: 6.109,
 				Update: time.Time{}},
-			common.Airfield{ID: "LSGB", ShortName: "BEX", Name: "BEX",
+			airfield.Airfield{ID: "LSGB", ShortName: "BEX", Name: "BEX",
 				Region: "CH", ICAO: "LSGB", Flags: 1024, Catalog: 0, Length: 0, Elevation: 399,
 				Runway: "1533", Frequency: 122.15, Latitude: 46.258, Longitude: 6.986,
 				Update: time.Time{}},
@@ -73,7 +73,7 @@ LSGB,BEX,BEX,CH,LSGB,1024,0,0,399,1533,122.15,46.258,6.986,0001-01-01 00:00:00 +
 ID,ShortName,Name,Region,ICAO,Flags,Catalog,Length,Elevation,Runway,Frequency,Latitude,Longitude,Update
 HABER,HABER,HABERE POC69,FR,,1032,0,0,1113,0119,122.5,46.270,6.463,0001-01-01 00:00:00 +0000 UTC,a
 `,
-		[]common.Airfield{common.Airfield{}},
+		[]airfield.Airfield{airfield.Airfield{}},
 		true,
 	},
 	{
@@ -82,7 +82,7 @@ HABER,HABER,HABERE POC69,FR,,1032,0,0,1113,0119,122.5,46.270,6.463,0001-01-01 00
 ID,ShortName,Name,Region,ICAO,Flags,Catalog,Length,Elevation,Runway,Frequency,Latitude,Longitude,Update
 HABER,HABER,HABERE POC69,FR,,badflags,0,0,1113,0119,122.5,46.270,6.463,0001-01-01 00:00:00 +0000 UTC
 `,
-		[]common.Airfield{common.Airfield{}},
+		[]airfield.Airfield{airfield.Airfield{}},
 		true,
 	},
 	{
@@ -91,7 +91,7 @@ HABER,HABER,HABERE POC69,FR,,badflags,0,0,1113,0119,122.5,46.270,6.463,0001-01-0
 ID,ShortName,Name,Region,ICAO,Flags,Catalog,Length,Elevation,Runway,Frequency,Latitude,Longitude,Update
 HABER,HABER,HABERE POC69,FR,,1032,badcatalog,0,1113,0119,122.5,46.270,6.463,0001-01-01 00:00:00 +0000 UTC
 `,
-		[]common.Airfield{common.Airfield{}},
+		[]airfield.Airfield{airfield.Airfield{}},
 		true,
 	},
 	{
@@ -100,7 +100,7 @@ HABER,HABER,HABERE POC69,FR,,1032,badcatalog,0,1113,0119,122.5,46.270,6.463,0001
 ID,ShortName,Name,Region,ICAO,Flags,Catalog,Length,Elevation,Runway,Frequency,Latitude,Longitude,Update
 HABER,HABER,HABERE POC69,FR,,1032,0,badlength,1113,0119,122.5,46.270,6.463,0001-01-01 00:00:00 +0000 UTC
 `,
-		[]common.Airfield{common.Airfield{}},
+		[]airfield.Airfield{airfield.Airfield{}},
 		true,
 	},
 	{
@@ -109,7 +109,7 @@ HABER,HABER,HABERE POC69,FR,,1032,0,badlength,1113,0119,122.5,46.270,6.463,0001-
 ID,ShortName,Name,Region,ICAO,Flags,Catalog,Length,Elevation,Runway,Frequency,Latitude,Longitude,Update
 HABER,HABER,HABERE POC69,FR,,1032,0,0,badelevation,0119,122.5,46.270,6.463,0001-01-01 00:00:00 +0000 UTC
 `,
-		[]common.Airfield{common.Airfield{}},
+		[]airfield.Airfield{airfield.Airfield{}},
 		true,
 	},
 	{
@@ -118,21 +118,21 @@ HABER,HABER,HABERE POC69,FR,,1032,0,0,badelevation,0119,122.5,46.270,6.463,0001-
 ID,ShortName,Name,Region,ICAO,Flags,Catalog,Length,Elevation,Runway,Frequency,Latitude,Longitude,Update
 HABER,HABER,HABERE POC69,FR,,1032,0,0,1113,0119,badfrequency,46.270,6.463,0001-01-01 00:00:00 +0000 UTC
 `,
-		[]common.Airfield{common.Airfield{}},
+		[]airfield.Airfield{airfield.Airfield{}},
 		true,
 	},
 	{
 		"parse with no records",
 		"",
-		[]common.Airfield{},
+		[]airfield.Airfield{},
 		true,
 	},
 }
 
 func TestCSV2Airfield(t *testing.T) {
 	for _, test := range csv2AirfieldTests {
-		result, err := CSV2Struct(test.in, reflect.ValueOf([]common.Airfield{}).Type(),
-			reflect.ValueOf(common.Airfield{}).Type())
+		result, err := CSV2Struct(test.in, reflect.ValueOf([]airfield.Airfield{}).Type(),
+			reflect.ValueOf(airfield.Airfield{}).Type())
 		if err != nil && test.err {
 			continue
 		} else if err != nil {
@@ -140,7 +140,7 @@ func TestCSV2Airfield(t *testing.T) {
 			continue
 		}
 
-		resultv := result.Interface().([]common.Airfield)
+		resultv := result.Interface().([]airfield.Airfield)
 		if len(resultv) != len(test.r) {
 			t.Errorf("%v :: expected %v but got %v airfields", test.t, len(test.r), len(resultv))
 			continue
@@ -156,7 +156,7 @@ func TestCSV2Airfield(t *testing.T) {
 
 type Airfield2CSVTest struct {
 	t   string
-	in  []common.Airfield
+	in  []airfield.Airfield
 	csv string
 	err bool
 }
@@ -164,8 +164,8 @@ type Airfield2CSVTest struct {
 var airfield2CSVTests = []Airfield2CSVTest{
 	{
 		"simple conversion",
-		[]common.Airfield{
-			common.Airfield{ID: "HABER", ShortName: "HABER", Name: "HABERE POC69",
+		[]airfield.Airfield{
+			airfield.Airfield{ID: "HABER", ShortName: "HABER", Name: "HABERE POC69",
 				Region: "FR", ICAO: "", Flags: 1032, Catalog: 0, Length: 0, Elevation: 1113,
 				Runway: "0119", Frequency: 122.5, Latitude: 46.270, Longitude: 6.463,
 				Update: time.Time{}},
@@ -177,14 +177,14 @@ HABER,HABER,HABERE POC69,FR,,1032,0,0,1113,0119,122.5,46.27,6.463,0001-01-01 00:
 	},
 	{
 		"conversion of empty array",
-		[]common.Airfield{},
+		[]airfield.Airfield{},
 		``,
 		false,
 	},
 	{
 		"conversion with all empty",
-		[]common.Airfield{
-			common.Airfield{ID: "", ShortName: "", Name: "",
+		[]airfield.Airfield{
+			airfield.Airfield{ID: "", ShortName: "", Name: "",
 				Region: "", ICAO: "", Flags: 0, Catalog: 0, Length: 0, Elevation: 0,
 				Runway: "", Frequency: 0, Latitude: 0.0, Longitude: 0.0, Update: time.Time{}},
 		},

--- a/util/spatial.go
+++ b/util/spatial.go
@@ -24,6 +24,7 @@ import (
 	"strconv"
 
 	"github.com/paulmach/go.geojson"
+	"github.com/rochaporto/ezgliding/airfield"
 	"github.com/rochaporto/ezgliding/common"
 )
 
@@ -59,8 +60,8 @@ func Struct2GeoJSON(features []interface{}) (*geojson.FeatureCollection, error) 
 		switch e.(type) {
 		default:
 			return nil, errors.New("geojson convertion not supported")
-		case common.Airfield:
-			f = airfield2GeoJSON([]common.Airfield{e.(common.Airfield)})
+		case airfield.Airfield:
+			f = airfield2GeoJSON([]airfield.Airfield{e.(airfield.Airfield)})
 		case common.Waypoint:
 			f = waypoint2GeoJSON([]common.Waypoint{e.(common.Waypoint)})
 		}
@@ -70,7 +71,7 @@ func Struct2GeoJSON(features []interface{}) (*geojson.FeatureCollection, error) 
 }
 
 // airfield2GeoJSON converts the given airfield to GeoJSON format.
-func airfield2GeoJSON(airfields []common.Airfield) []*geojson.Feature {
+func airfield2GeoJSON(airfields []airfield.Airfield) []*geojson.Feature {
 	result := []*geojson.Feature{}
 	for _, airfield := range airfields {
 		g := geojson.NewPointFeature([]float64{airfield.Longitude, airfield.Latitude})
@@ -109,7 +110,7 @@ func waypoint2GeoJSON(waypoints []common.Waypoint) []*geojson.Feature {
 }
 
 // GeoJSON2Struct returns airfield, waypoint, etc objects from the given GeoJSON.
-// The resulting array contains distinct types (common.Airfield, common.Waypoint,
+// The resulting array contains distinct types (airfield.Airfield, common.Waypoint,
 // common.Airspace, ...) and the unmarshaling is done with the same rules as
 // described in Struct2GeoJSON.
 func GeoJSON2Struct(json string) ([]interface{}, error) {
@@ -134,8 +135,8 @@ func GeoJSON2Struct(json string) ([]interface{}, error) {
 	return result, nil
 }
 
-func feature2Airfield(f *geojson.Feature) common.Airfield {
-	a := common.Airfield{
+func feature2Airfield(f *geojson.Feature) airfield.Airfield {
+	a := airfield.Airfield{
 		ID: f.PropertyMustString("ID"), ShortName: f.PropertyMustString("ShortName"),
 		Name: f.PropertyMustString("Name"), Region: f.PropertyMustString("Region"),
 		ICAO: f.PropertyMustString("ICAO"), Flags: f.PropertyMustInt("Flags"),

--- a/util/spatial_test.go
+++ b/util/spatial_test.go
@@ -23,6 +23,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/rochaporto/ezgliding/airfield"
 	"github.com/rochaporto/ezgliding/common"
 )
 
@@ -75,7 +76,7 @@ var struct2GeoJSONTests = []Struct2GeoJSONTest{
 	Struct2GeoJSONTest{
 		"simple airfield conversion",
 		[]interface{}{
-			common.Airfield{ID: "HABER", ShortName: "HABER", Name: "HABERE POC69",
+			airfield.Airfield{ID: "HABER", ShortName: "HABER", Name: "HABERE POC69",
 				Region: "FR", ICAO: "HHHH", Flags: 1032, Catalog: 69, Length: 900, Elevation: 1113,
 				Runway: "0119", Frequency: 122.5, Latitude: 46.270, Longitude: 6.463},
 		},
@@ -94,7 +95,7 @@ var struct2GeoJSONTests = []Struct2GeoJSONTest{
 	Struct2GeoJSONTest{
 		"multiple type conversion",
 		[]interface{}{
-			common.Airfield{ID: "HABER", ShortName: "HABER", Name: "HABERE POC69",
+			airfield.Airfield{ID: "HABER", ShortName: "HABER", Name: "HABERE POC69",
 				Region: "FR", ICAO: "HHHH", Flags: 1032, Catalog: 69, Length: 900, Elevation: 1113,
 				Runway: "0119", Frequency: 122.5, Latitude: 46.270, Longitude: 6.463},
 			common.Waypoint{

--- a/web/cache_test.go
+++ b/web/cache_test.go
@@ -28,7 +28,7 @@ import (
 	"time"
 
 	"github.com/bradfitz/gomemcache/memcache"
-	"github.com/rochaporto/ezgliding/common"
+	"github.com/rochaporto/ezgliding/airfield"
 	"github.com/rochaporto/ezgliding/context"
 	"github.com/rochaporto/ezgliding/mock"
 	"github.com/rochaporto/ezgliding/util"
@@ -50,8 +50,8 @@ func TestMemcacheBadServer(t *testing.T) {
 }
 
 func TestMemcache(t *testing.T) {
-	airfields := []common.Airfield{
-		common.Airfield{ID: "MockID", ShortName: "MockShortName", Name: "MockName",
+	airfields := []airfield.Airfield{
+		airfield.Airfield{ID: "MockID", ShortName: "MockShortName", Name: "MockName",
 			Region: "FR", ICAO: "AAAA", Flags: 0, Catalog: 11, Length: 1000, Elevation: 2000,
 			Runway: "32R", Frequency: 123.45, Latitude: 32.533, Longitude: 100.376},
 	}
@@ -63,7 +63,7 @@ func TestMemcache(t *testing.T) {
 
 	// using a mock object to return airfields
 	mock := &mock.Mock{
-		GetAirfieldF: func(regions []string, updatedSince time.Time) ([]common.Airfield, error) {
+		GetAirfieldF: func(regions []string, updatedSince time.Time) ([]airfield.Airfield, error) {
 			return airfields, nil
 		},
 	}

--- a/web/handler.go
+++ b/web/handler.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"github.com/golang/glog"
+	"github.com/rochaporto/ezgliding/airfield"
 	"github.com/rochaporto/ezgliding/common"
 )
 
@@ -73,8 +74,8 @@ func (srv *Server) airspaceHandler(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
-	airfield := srv.ctx.Airfield
-	airfields, err := airfield.(common.Airfielder).GetAirfield(params["region"], updated)
+	afield := srv.ctx.Airfield
+	airfields, err := afield.(airfield.Airfielder).GetAirfield(params["region"], updated)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return

--- a/web/web_test.go
+++ b/web/web_test.go
@@ -29,6 +29,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/rochaporto/ezgliding/airfield"
 	"github.com/rochaporto/ezgliding/common"
 	"github.com/rochaporto/ezgliding/config"
 	"github.com/rochaporto/ezgliding/context"
@@ -50,7 +51,7 @@ var serverTests = []ServerTest{
 	{
 		"query airfield json",
 		[]interface{}{
-			common.Airfield{ID: "MockID", ShortName: "MockShortName", Name: "MockName",
+			airfield.Airfield{ID: "MockID", ShortName: "MockShortName", Name: "MockName",
 				Region: "FR", ICAO: "AAAA", Flags: 0, Catalog: 11, Length: 1000, Elevation: 2000,
 				Runway: "32R", Frequency: 123.45, Latitude: 32.533, Longitude: 100.376},
 		},
@@ -63,7 +64,7 @@ var serverTests = []ServerTest{
 	{
 		"query airfield json accept in querystring",
 		[]interface{}{
-			common.Airfield{ID: "MockID", ShortName: "MockShortName", Name: "MockName",
+			airfield.Airfield{ID: "MockID", ShortName: "MockShortName", Name: "MockName",
 				Region: "FR", ICAO: "AAAA", Flags: 0, Catalog: 11, Length: 1000, Elevation: 2000,
 				Runway: "32R", Frequency: 123.45, Latitude: 32.533, Longitude: 100.376},
 		},
@@ -158,18 +159,18 @@ var serverTests = []ServerTest{
 }
 
 func serverFromTest(test ServerTest) Server {
-	airfields := []common.Airfield{}
+	airfields := []airfield.Airfield{}
 	waypoints := []common.Waypoint{}
 	for _, a := range test.dt {
 		switch a.(type) {
-		case common.Airfield:
-			airfields = append(airfields, a.(common.Airfield))
+		case airfield.Airfield:
+			airfields = append(airfields, a.(airfield.Airfield))
 		case common.Waypoint:
 			waypoints = append(waypoints, a.(common.Waypoint))
 		}
 	}
 	mock := &mock.Mock{
-		GetAirfieldF: func(regions []string, updatedSince time.Time) ([]common.Airfield, error) {
+		GetAirfieldF: func(regions []string, updatedSince time.Time) ([]airfield.Airfield, error) {
 			return airfields, test.perr
 		},
 		GetWaypointF: func(regions []string, updatedSince time.Time) ([]common.Waypoint, error) {

--- a/welt2000/welt2000_test.go
+++ b/welt2000/welt2000_test.go
@@ -28,6 +28,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/rochaporto/ezgliding/airfield"
 	"github.com/rochaporto/ezgliding/common"
 	"github.com/rochaporto/ezgliding/config"
 )
@@ -40,7 +41,7 @@ type GetAirfieldTest struct {
 	rss string
 	rg  string
 	d   time.Time
-	rs  []common.Airfield
+	rs  []airfield.Airfield
 	err bool
 }
 
@@ -50,10 +51,10 @@ var getAirfieldTests = []GetAirfieldTest{
 		"./t/test-releases-list.xml",
 		"FR",
 		time.Time{},
-		[]common.Airfield{
-			common.Airfield{
+		[]airfield.Airfield{
+			airfield.Airfield{
 				ID: "HABER", Name: "HABERE POC69", ShortName: "HABER", Region: "FR",
-				ICAO: "", Flags: common.GliderSite | common.Grass, Catalog: 0,
+				ICAO: "", Flags: airfield.GliderSite | airfield.Grass, Catalog: 0,
 				Length: 0, Elevation: 1113, Runway: "0119", Frequency: 122.5,
 				Latitude: 46.26972222222222, Longitude: 6.463333333333334,
 				Update: time.Date(2014, time.February, 24, 12, 0, 0, 0, GMT),
@@ -66,7 +67,7 @@ var getAirfieldTests = []GetAirfieldTest{
 		"./t/test-releases-list.xml",
 		"FR",
 		time.Date(2014, time.February, 25, 0, 0, 0, 0, time.UTC),
-		[]common.Airfield{},
+		[]airfield.Airfield{},
 		false,
 	},
 	{"get airfield missing rss",
@@ -74,7 +75,7 @@ var getAirfieldTests = []GetAirfieldTest{
 		"./t/missing-release-list.xml",
 		"FR",
 		time.Time{},
-		[]common.Airfield{},
+		[]airfield.Airfield{},
 		true,
 	},
 	{"get airfield missing release",
@@ -82,7 +83,7 @@ var getAirfieldTests = []GetAirfieldTest{
 		"./t/test-releases-list.xml",
 		"FR",
 		time.Time{},
-		[]common.Airfield{},
+		[]airfield.Airfield{},
 		true,
 	},
 	{"get airfield with 0 values for region",
@@ -90,7 +91,7 @@ var getAirfieldTests = []GetAirfieldTest{
 		"./t/test-releases-list.xml",
 		"ZZ",
 		time.Time{},
-		[]common.Airfield{},
+		[]airfield.Airfield{},
 		false,
 	},
 }
@@ -108,7 +109,7 @@ func TestGetAirfield(t *testing.T) {
 			continue
 		}
 
-		var airfields []common.Airfield
+		var airfields []airfield.Airfield
 		airfields, err = plugin.GetAirfield([]string{test.rg}, test.d)
 		if err != nil && test.err {
 			continue
@@ -372,22 +373,22 @@ func TestParseComment(t *testing.T) {
 func TestParseAirfield(t *testing.T) {
 	r := Release{}
 	r.Parse([]byte("ANNEM1 ANNEMASSE       #LFLIA129123012587 494N461131E0061606FRQ0"))
-	airfield := r.Airfields[0]
+	afield := r.Airfields[0]
 
-	expected := common.Airfield{ID: "LFLI", ShortName: "ANNEM",
-		Name: "ANNEMASSE", ICAO: "LFLI", Flags: 0 | common.Asphalt,
+	expected := airfield.Airfield{ID: "LFLI", ShortName: "ANNEM",
+		Name: "ANNEMASSE", ICAO: "LFLI", Flags: 0 | airfield.Asphalt,
 		Length: 1290, Runway: "1230", Frequency: 125.87, Elevation: 494,
 		Latitude: 46.19194444444444, Longitude: 6.2683333333333335, Region: "FR"}
-	if airfield != expected {
-		t.Errorf("failed to parse airfield :: expected %v got %v", expected, airfield)
+	if afield != expected {
+		t.Errorf("failed to parse airfield :: expected %v got %v", expected, afield)
 	}
 }
 
 func TestParseUnclearAirstrip(t *testing.T) {
 	r := Release{}
 	r.Parse([]byte("AMBL21 AMBLETEUSE AERO #   ?G       1      32N504901E0013658FRQ0"))
-	airfield := r.Airfields[0]
-	if airfield.Flags&common.UnclearAirstrip != 1 {
+	afield := r.Airfields[0]
+	if afield.Flags&airfield.UnclearAirstrip != 1 {
 		t.Errorf("Parse failed for unclear airstrip")
 	}
 }
@@ -396,14 +397,14 @@ func TestParseGliderSite(t *testing.T) {
 	r := Release{}
 	// case GLD#
 	r.Parse([]byte("CHALA1 CHALAIS      GLD#LFIHG 83072512350  88N451605E0000058FRQ0"))
-	airfield := r.Airfields[0]
-	if airfield.Flags&common.GliderSite == 0 {
+	afield := r.Airfields[0]
+	if afield.Flags&airfield.GliderSite == 0 {
 		t.Errorf("Parse failed for glider site")
 	}
 	// case GLD#GLD
 	r.Parse([]byte("HABER1 HABERE POC69 GLD#GLD!G 980119122501113N461611E0062748FRP3"))
-	airfield = r.Airfields[0]
-	if airfield.Flags&common.GliderSite == 0 {
+	afield = r.Airfields[0]
+	if afield.Flags&airfield.GliderSite == 0 {
 		t.Errorf("Parse failed for glider site")
 	}
 }
@@ -411,16 +412,16 @@ func TestParseGliderSite(t *testing.T) {
 func TestParseULMSite(t *testing.T) {
 	r := Release{}
 	r.Parse([]byte("CERVE2 CERVENS UL      *ULM!G 28052312350 619N461713E0062638FRQ0"))
-	airfield := r.Airfields[0]
-	if airfield.Flags&common.ULMSite == 0 {
+	afield := r.Airfields[0]
+	if afield.Flags&airfield.ULMSite == 0 {
 		t.Errorf("Parse failed for ulm site")
 	}
 }
 func TestParseAsphalt(t *testing.T) {
 	r := Release{}
 	r.Parse([]byte("ANNEM1 ANNEMASSE       #LFLIA129123012587 494N461131E0061606FRQ0"))
-	airfield := r.Airfields[0]
-	if airfield.Flags&common.Asphalt == 0 {
+	afield := r.Airfields[0]
+	if afield.Flags&airfield.Asphalt == 0 {
 		t.Errorf("Parse failed for asphalt airstrip")
 	}
 }
@@ -428,8 +429,8 @@ func TestParseAsphalt(t *testing.T) {
 func TestParseConcrete(t *testing.T) {
 	r := Release{}
 	r.Parse([]byte("ANNEM1 ANNEMASSE       #LFLIC129123012587 494N461131E0061606FRQ0"))
-	airfield := r.Airfields[0]
-	if airfield.Flags&common.Concrete == 0 {
+	afield := r.Airfields[0]
+	if afield.Flags&airfield.Concrete == 0 {
 		t.Errorf("Parse failed for concrete airstrip")
 	}
 }
@@ -437,8 +438,8 @@ func TestParseConcrete(t *testing.T) {
 func TestParseLoam(t *testing.T) {
 	r := Release{}
 	r.Parse([]byte("ANNEM1 ANNEMASSE       #LFLIL129123012587 494N461131E0061606FRQ0"))
-	airfield := r.Airfields[0]
-	if airfield.Flags&common.Loam == 0 {
+	afield := r.Airfields[0]
+	if afield.Flags&airfield.Loam == 0 {
 		t.Errorf("Parse failed for loam airstrip")
 	}
 }
@@ -446,8 +447,8 @@ func TestParseLoam(t *testing.T) {
 func TestParseSand(t *testing.T) {
 	r := Release{}
 	r.Parse([]byte("ANNEM1 ANNEMASSE       #LFLIS129123012587 494N461131E0061606FRQ0"))
-	airfield := r.Airfields[0]
-	if airfield.Flags&common.Sand == 0 {
+	afield := r.Airfields[0]
+	if afield.Flags&airfield.Sand == 0 {
 		t.Errorf("Parse failed for sand airstrip")
 	}
 }
@@ -455,8 +456,8 @@ func TestParseSand(t *testing.T) {
 func TestParseClay(t *testing.T) {
 	r := Release{}
 	r.Parse([]byte("ANNEM1 ANNEMASSE       #LFLIY129123012587 494N461131E0061606FRQ0"))
-	airfield := r.Airfields[0]
-	if airfield.Flags&common.Clay == 0 {
+	afield := r.Airfields[0]
+	if afield.Flags&airfield.Clay == 0 {
 		t.Errorf("Parse failed for asphalt airstrip")
 	}
 }
@@ -464,8 +465,8 @@ func TestParseClay(t *testing.T) {
 func TestParseGrass(t *testing.T) {
 	r := Release{}
 	r.Parse([]byte("ANNEM1 ANNEMASSE       #LFLIG129123012587 494N461131E0061606FRQ0"))
-	airfield := r.Airfields[0]
-	if airfield.Flags&common.Grass == 0 {
+	afield := r.Airfields[0]
+	if afield.Flags&airfield.Grass == 0 {
 		t.Errorf("Parse failed for grass airstrip")
 	}
 }
@@ -473,8 +474,8 @@ func TestParseGrass(t *testing.T) {
 func TestParseGravel(t *testing.T) {
 	r := Release{}
 	r.Parse([]byte("ANNEM1 ANNEMASSE       #LFLIV129123012587 494N461131E0061606FRQ0"))
-	airfield := r.Airfields[0]
-	if airfield.Flags&common.Gravel == 0 {
+	afield := r.Airfields[0]
+	if afield.Flags&airfield.Gravel == 0 {
 		t.Errorf("Parse failed for gravel airstrip")
 	}
 }
@@ -482,8 +483,8 @@ func TestParseGravel(t *testing.T) {
 func TestParseDirt(t *testing.T) {
 	r := Release{}
 	r.Parse([]byte("ANNEM1 ANNEMASSE       #LFLID129123012587 494N461131E0061606FRQ0"))
-	airfield := r.Airfields[0]
-	if airfield.Flags&common.Dirt == 0 {
+	afield := r.Airfields[0]
+	if afield.Flags&airfield.Dirt == 0 {
 		t.Errorf("Parse failed for dirt airstrip")
 	}
 }
@@ -491,8 +492,8 @@ func TestParseDirt(t *testing.T) {
 func TestParseUnknownRunwayType(t *testing.T) {
 	r := Release{}
 	r.Parse([]byte("ANNEM1 ANNEMASSE       #LFLIO129123012587 494N461131E0061606FRQ0"))
-	airfield := r.Airfields[0]
-	if airfield.Flags != 0 {
+	afield := r.Airfields[0]
+	if afield.Flags != 0 {
 		t.Errorf("Parse failed for invalid runway type")
 	}
 }
@@ -500,8 +501,8 @@ func TestParseUnknownRunwayType(t *testing.T) {
 func TestParseCatalogNumber(t *testing.T) {
 	r := Release{}
 	r.Parse([]byte("BONVI2 BONNEVILLE      *FL53S 400523      450N460441E0062310FRP0"))
-	airfield := r.Airfields[0]
-	if airfield.Catalog != 53 || airfield.Flags&common.Outlanding == 0 {
+	afield := r.Airfields[0]
+	if afield.Catalog != 53 || afield.Flags&airfield.Outlanding == 0 {
 		t.Errorf("Parse failed for outlanding catalog number")
 	}
 }


### PR DESCRIPTION
refactors all airfield interfaces and types/structs moving them to their
own airfield pkg (was in common). this is part of the refactoring effort
to get rid of common.

Implements #69.