### PR TITLE
refactor waypoint into own pkg (was common).

### DIFF
--- a/cli/waypoint.go
+++ b/cli/waypoint.go
@@ -28,10 +28,10 @@ import (
 
 	commander "code.google.com/p/go-commander"
 	"github.com/golang/glog"
-	"github.com/rochaporto/ezgliding/common"
 	"github.com/rochaporto/ezgliding/context"
 	"github.com/rochaporto/ezgliding/plugin"
 	"github.com/rochaporto/ezgliding/util"
+	"github.com/rochaporto/ezgliding/waypoint"
 )
 
 // CmdWaypointGet command gets waypoint information and outputs the result.
@@ -49,7 +49,7 @@ Gets waypoint information according to the given parameters.
 func runWaypointGet(cmd *commander.Command, args []string) {
 	var err error
 	ctx := context.Ctx
-	waypoint := ctx.Waypoint
+	wpoint := ctx.Waypoint
 
 	tafter := time.Time{}
 	if *after != "" {
@@ -59,7 +59,7 @@ func runWaypointGet(cmd *commander.Command, args []string) {
 			return
 		}
 	}
-	waypoints, err := waypoint.(common.Waypointer).GetWaypoint(strings.Split(*region, ","), tafter)
+	waypoints, err := wpoint.(waypoint.Waypointer).GetWaypoint(strings.Split(*region, ","), tafter)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to get waypoint :: %v", err)
 		// FIXME: must return -1, but no way now to check this in test
@@ -99,8 +99,8 @@ func runWaypointPut(cmd *commander.Command, args []string) {
 		fmt.Fprintf(os.Stderr, "failed to init plugin '%v' :: %v\n", pluginID, err)
 		return
 	}
-	waypoint := ctx.Waypoint
-	waypoints, err := waypoint.(common.Waypointer).GetWaypoint(strings.Split(*region, ","), time.Time{})
+	wpoint := ctx.Waypoint
+	waypoints, err := wpoint.(waypoint.Waypointer).GetWaypoint(strings.Split(*region, ","), time.Time{})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to get waypoint :: %v\n", err)
 		return
@@ -108,7 +108,7 @@ func runWaypointPut(cmd *commander.Command, args []string) {
 	glog.V(5).Infof("putting %v waypoints", len(waypoints))
 	glog.V(20).Infof("%v", waypoints)
 	if len(waypoints) > 0 {
-		err = destPlugin.(common.Waypointer).PutWaypoint(waypoints)
+		err = destPlugin.(waypoint.Waypointer).PutWaypoint(waypoints)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "failed to put waypoints :: %v\n", err)
 			return

--- a/cli/waypoint_test.go
+++ b/cli/waypoint_test.go
@@ -25,11 +25,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/rochaporto/ezgliding/common"
 	"github.com/rochaporto/ezgliding/config"
 	"github.com/rochaporto/ezgliding/context"
 	"github.com/rochaporto/ezgliding/mock"
 	"github.com/rochaporto/ezgliding/plugin"
+	"github.com/rochaporto/ezgliding/waypoint"
 )
 
 // ExampleWaypointGet uses the mock waypoint implementation to query data and
@@ -38,28 +38,28 @@ import (
 func ExampleWaypointGet() {
 	ctx := context.Context{
 		Waypoint: &mock.Mock{
-			GetWaypointF: func(regions []string, updatedSince time.Time) ([]common.Waypoint, error) {
-				waypoints := []common.Waypoint{
-					common.Waypoint{
+			GetWaypointF: func(regions []string, updatedSince time.Time) ([]waypoint.Waypoint, error) {
+				waypoints := []waypoint.Waypoint{
+					waypoint.Waypoint{
 						ID: "MockID1", Name: "MockName",
 						Description: "MockDescription", Region: "FR", Flags: 0,
 						Elevation: 2000, Latitude: 32.533, Longitude: 100.376,
 						Update: time.Date(2014, 02, 01, 0, 0, 0, 0, time.UTC),
 					},
-					common.Waypoint{
+					waypoint.Waypoint{
 						ID: "MockID2", Name: "MockName",
 						Description: "MockDescription", Region: "CH", Flags: 0,
 						Elevation: 2000, Latitude: 32.533, Longitude: 100.376,
 						Update: time.Date(2014, 02, 02, 0, 0, 0, 0, time.UTC),
 					},
-					common.Waypoint{
+					waypoint.Waypoint{
 						ID: "MockID3", Name: "MockName",
 						Description: "MockDescription", Region: "CH", Flags: 0,
 						Elevation: 2000, Latitude: 32.533, Longitude: 100.376,
 						Update: time.Date(2014, 02, 03, 0, 0, 0, 0, time.UTC),
 					},
 				}
-				result := []common.Waypoint{}
+				result := []waypoint.Waypoint{}
 				for _, waypoint := range waypoints {
 					b := false
 					for _, r := range regions {
@@ -87,7 +87,7 @@ func ExampleWaypointGet() {
 func TestWaypointGetFailed(t *testing.T) {
 	ctx := context.Context{
 		Waypoint: &mock.Mock{
-			GetWaypointF: func(regions []string, updatedSince time.Time) ([]common.Waypoint, error) {
+			GetWaypointF: func(regions []string, updatedSince time.Time) ([]waypoint.Waypoint, error) {
 				return nil, errors.New("mock testing get waypoint failed")
 			},
 		},
@@ -101,7 +101,7 @@ func TestWaypointGetFailed(t *testing.T) {
 func TestWaypointGetBadAfter(t *testing.T) {
 	ctx := context.Context{
 		Waypoint: &mock.Mock{
-			GetWaypointF: func(regions []string, updatedSince time.Time) ([]common.Waypoint, error) {
+			GetWaypointF: func(regions []string, updatedSince time.Time) ([]waypoint.Waypoint, error) {
 				return nil, nil
 			},
 		},
@@ -117,9 +117,9 @@ func TestWaypointGetBadAfter(t *testing.T) {
 func ExampleWaypointPut() {
 	ctx := context.Context{
 		Waypoint: &mock.Mock{
-			GetWaypointF: func(regions []string, updatedSince time.Time) ([]common.Waypoint, error) {
-				return []common.Waypoint{
-					common.Waypoint{ID: "MockID", Name: "MockName", Description: "MockDescription",
+			GetWaypointF: func(regions []string, updatedSince time.Time) ([]waypoint.Waypoint, error) {
+				return []waypoint.Waypoint{
+					waypoint.Waypoint{ID: "MockID", Name: "MockName", Description: "MockDescription",
 						Region: "FR", Flags: 0, Elevation: 2000, Latitude: 32.533, Longitude: 100.576},
 				}, nil
 			},
@@ -134,7 +134,7 @@ func ExampleWaypointPut() {
 func TestWaypointPutFailed(t *testing.T) {
 	err := plugin.Register(plugin.ID("wpputfailed"), plugin.Pluginer(
 		&mock.Mock{
-			PutWaypointF: func(waypoints []common.Waypoint) error {
+			PutWaypointF: func(waypoints []waypoint.Waypoint) error {
 				return errors.New("mock testing put waypoint failed")
 			},
 		}))
@@ -143,8 +143,8 @@ func TestWaypointPutFailed(t *testing.T) {
 	}
 	ctx := context.Context{
 		Waypoint: &mock.Mock{
-			GetWaypointF: func(regions []string, updatedSince time.Time) ([]common.Waypoint, error) {
-				return []common.Waypoint{common.Waypoint{}}, nil
+			GetWaypointF: func(regions []string, updatedSince time.Time) ([]waypoint.Waypoint, error) {
+				return []waypoint.Waypoint{waypoint.Waypoint{}}, nil
 			},
 		},
 	}
@@ -155,7 +155,7 @@ func TestWaypointPutFailed(t *testing.T) {
 func TestWaypointPutBadGet(t *testing.T) {
 	ctx := context.Context{
 		Waypoint: &mock.Mock{
-			GetWaypointF: func(regions []string, updatedSince time.Time) ([]common.Waypoint, error) {
+			GetWaypointF: func(regions []string, updatedSince time.Time) ([]waypoint.Waypoint, error) {
 				return nil, errors.New("mock testing get waypoint failed")
 			},
 		},
@@ -184,8 +184,8 @@ func TestWaypointPutFailInit(t *testing.T) {
 	}
 	ctx := context.Context{
 		Waypoint: &mock.Mock{
-			GetWaypointF: func(regions []string, updatedSince time.Time) ([]common.Waypoint, error) {
-				return []common.Waypoint{common.Waypoint{}}, nil
+			GetWaypointF: func(regions []string, updatedSince time.Time) ([]waypoint.Waypoint, error) {
+				return []waypoint.Waypoint{waypoint.Waypoint{}}, nil
 			},
 		},
 	}

--- a/context/context.go
+++ b/context/context.go
@@ -30,6 +30,7 @@ import (
 	"github.com/rochaporto/ezgliding/common"
 	"github.com/rochaporto/ezgliding/config"
 	"github.com/rochaporto/ezgliding/flight"
+	"github.com/rochaporto/ezgliding/waypoint"
 )
 
 // FIXME(rocha): This should really go away.
@@ -45,12 +46,12 @@ type Context struct {
 	Airspace common.Airspacer
 	Airfield airfield.Airfielder
 	Flight   flight.Flighter
-	Waypoint common.Waypointer
+	Waypoint waypoint.Waypointer
 }
 
 // NewContext returns a new Context object.
 func NewContext(cfg config.Config, airspace common.Airspacer, airfield airfield.Airfielder,
-	flight flight.Flighter, waypoint common.Waypointer) (Context, error) {
+	flight flight.Flighter, waypoint waypoint.Waypointer) (Context, error) {
 	return Context{Config: cfg, Airspace: airspace, Airfield: airfield,
 		Flight: flight, Waypoint: waypoint}, nil
 }

--- a/context/context_test.go
+++ b/context/context_test.go
@@ -27,13 +27,14 @@ import (
 	"github.com/rochaporto/ezgliding/config"
 	"github.com/rochaporto/ezgliding/flight"
 	"github.com/rochaporto/ezgliding/mock"
+	"github.com/rochaporto/ezgliding/waypoint"
 )
 
 func TestNewContext(t *testing.T) {
 	mock := mock.Mock{}
 	_, err := NewContext(config.Config{}, common.Airspacer(&mock),
 		airfield.Airfielder(&mock), flight.Flighter(&mock),
-		common.Waypointer(&mock))
+		waypoint.Waypointer(&mock))
 	if err != nil {
 		t.Errorf("Failed to get new context :: %v", err)
 	}

--- a/fusiontables/waypoint.go
+++ b/fusiontables/waypoint.go
@@ -25,12 +25,12 @@ import (
 	"time"
 
 	"github.com/golang/glog"
-	"github.com/rochaporto/ezgliding/common"
 	"github.com/rochaporto/ezgliding/util"
+	"github.com/rochaporto/ezgliding/waypoint"
 )
 
 // GetWaypoint follows common.GetWaypoint().
-func (ft *FusionTables) GetWaypoint(regions []string, updatedSince time.Time) ([]common.Waypoint, error) {
+func (ft *FusionTables) GetWaypoint(regions []string, updatedSince time.Time) ([]waypoint.Waypoint, error) {
 	glog.V(10).Infof("GetWaypoint with regions %v and updatedSince %v", regions, updatedSince)
 
 	var qry string
@@ -47,19 +47,19 @@ func (ft *FusionTables) GetWaypoint(regions []string, updatedSince time.Time) ([
 	}
 	glog.V(20).Infof("unparsed response :: %v", resp)
 
-	r, err := util.CSV2Struct(resp, reflect.ValueOf([]common.Waypoint{}).Type(),
-		reflect.ValueOf(common.Waypoint{}).Type())
+	r, err := util.CSV2Struct(resp, reflect.ValueOf([]waypoint.Waypoint{}).Type(),
+		reflect.ValueOf(waypoint.Waypoint{}).Type())
 	if err != nil {
 		return nil, err
 	}
-	result := r.Interface().([]common.Waypoint)
+	result := r.Interface().([]waypoint.Waypoint)
 	glog.V(5).Infof("request %v returned %v results", qry, len(result))
 
 	return result, nil
 }
 
 // PutWaypoint follows common.PutWaypoint().
-func (ft *FusionTables) PutWaypoint(waypoints []common.Waypoint) error {
+func (ft *FusionTables) PutWaypoint(waypoints []waypoint.Waypoint) error {
 	csv := util.Struct2CSV(waypoints)
 	resp, err := ft.doImport(csv, ft.WaypointTableID)
 	if err != nil {

--- a/fusiontables/waypoint_test.go
+++ b/fusiontables/waypoint_test.go
@@ -27,8 +27,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/rochaporto/ezgliding/common"
 	"github.com/rochaporto/ezgliding/config"
+	"github.com/rochaporto/ezgliding/waypoint"
 )
 
 type GetWaypointTest struct {
@@ -36,7 +36,7 @@ type GetWaypointTest struct {
 	rg  []string
 	tm  time.Time
 	rp  string
-	rs  []common.Waypoint
+	rs  []waypoint.Waypoint
 	err bool
 }
 
@@ -49,8 +49,8 @@ var getGetWaypointTests = []GetWaypointTest{
 ID,Name,Description,Region,Flags,Elevation,Latitude,Longitude,Update
 FURKAP,FURKAP,FURKAPASS PASSHOEHE,CH,0,2432,46.270,6.463,0001-01-01 00:00:00 +0000 UTC
 `,
-		[]common.Waypoint{
-			common.Waypoint{ID: "FURKAP", Name: "FURKAP", Description: "FURKAPASS PASSHOEHE",
+		[]waypoint.Waypoint{
+			waypoint.Waypoint{ID: "FURKAP", Name: "FURKAP", Description: "FURKAPASS PASSHOEHE",
 				Region: "CH", Flags: 0, Elevation: 2432,
 				Latitude: 46.270, Longitude: 6.463},
 		},
@@ -64,7 +64,7 @@ FURKAP,FURKAP,FURKAPASS PASSHOEHE,CH,0,2432,46.270,6.463,0001-01-01 00:00:00 +00
 ID,Name,Description,Region,Flags,Elevation,Latitude,Longitude,Update
 FURKAP,FURKAP,FURKAPASS PASSHOEHE,CH,0,2432,46.270,6.463,0001-01-01 00:00:00 +0000 UTC,a
 `,
-		[]common.Waypoint{common.Waypoint{}},
+		[]waypoint.Waypoint{waypoint.Waypoint{}},
 		true,
 	},
 	{
@@ -75,8 +75,8 @@ FURKAP,FURKAP,FURKAPASS PASSHOEHE,CH,0,2432,46.270,6.463,0001-01-01 00:00:00 +00
 ID,Name,Description,Region,Flags,Elevation,Latitude,Longitude,Update
 FURKAP,FURKAP,FURKAPASS PASSHOEHE,CH,0,2432,46.270,6.463,0001-01-01 00:00:00 +0000 UTC
 `,
-		[]common.Waypoint{
-			common.Waypoint{ID: "FURKAP", Name: "FURKAP", Description: "FURKAPASS PASSHOEHE",
+		[]waypoint.Waypoint{
+			waypoint.Waypoint{ID: "FURKAP", Name: "FURKAP", Description: "FURKAPASS PASSHOEHE",
 				Region: "CH", Flags: 0, Elevation: 2432,
 				Latitude: 46.270, Longitude: 6.463},
 		},
@@ -151,7 +151,7 @@ func TestGetWaypointWithMalformedURL(t *testing.T) {
 
 type PutWaypointTest struct {
 	t   string
-	in  []common.Waypoint
+	in  []waypoint.Waypoint
 	csv string
 	err bool
 }
@@ -159,8 +159,8 @@ type PutWaypointTest struct {
 var putWaypointTests = []PutWaypointTest{
 	{
 		"simple update",
-		[]common.Waypoint{
-			common.Waypoint{ID: "FURKAP", Name: "FURKAP", Description: "FURKAPASS PASSHOEHE",
+		[]waypoint.Waypoint{
+			waypoint.Waypoint{ID: "FURKAP", Name: "FURKAP", Description: "FURKAPASS PASSHOEHE",
 				Region: "CH", Flags: 0, Elevation: 2432,
 				Latitude: 46.270, Longitude: 6.463},
 		},
@@ -171,8 +171,8 @@ FURKAP,FURKAP,FURKAPASS PASSHOEHE,CH,0,2432,46.27,6.463,0001-01-01 00:00:00 +000
 	},
 	{
 		"simple failure",
-		[]common.Waypoint{
-			common.Waypoint{ID: "FURKAP", Name: "FURKAP", Description: "FURKAPASS PASSHOEHE",
+		[]waypoint.Waypoint{
+			waypoint.Waypoint{ID: "FURKAP", Name: "FURKAP", Description: "FURKAPASS PASSHOEHE",
 				Region: "CH", Flags: 0, Elevation: 2432,
 				Latitude: 46.270, Longitude: 6.463},
 		},
@@ -223,7 +223,7 @@ func TestPutWaypointWithMissingLocation(t *testing.T) {
 	if err != nil {
 		t.Errorf("Failed to initialize plugin :: %v", err)
 	}
-	err = plugin.PutWaypoint([]common.Waypoint{})
+	err = plugin.PutWaypoint([]waypoint.Waypoint{})
 	if err == nil {
 		t.Errorf("expected error but was successful")
 	}
@@ -238,7 +238,7 @@ func TestPutWaypointWithMalformedURL(t *testing.T) {
 	if err != nil {
 		t.Errorf("Failed to initialize plugin :: %v", err)
 	}
-	err = plugin.PutWaypoint([]common.Waypoint{})
+	err = plugin.PutWaypoint([]waypoint.Waypoint{})
 	if err == nil {
 		t.Errorf("expected error but was successful")
 	}
@@ -258,8 +258,8 @@ func TestPutWaypointWithBadStatus(t *testing.T) {
 	if err != nil {
 		t.Errorf("failed to initialize plugin :: %v", err)
 	}
-	err = plugin.PutWaypoint([]common.Waypoint{
-		common.Waypoint{ID: "aFURKAP", Name: "FURKAP", Description: "FURKAPASS PASSHOEHE",
+	err = plugin.PutWaypoint([]waypoint.Waypoint{
+		waypoint.Waypoint{ID: "aFURKAP", Name: "FURKAP", Description: "FURKAPASS PASSHOEHE",
 			Region: "CH", Flags: 0, Elevation: 2432,
 			Latitude: 46.270, Longitude: 6.463},
 	})

--- a/main.go
+++ b/main.go
@@ -31,6 +31,7 @@ import (
 	"github.com/rochaporto/ezgliding/context"
 	"github.com/rochaporto/ezgliding/flight"
 	"github.com/rochaporto/ezgliding/plugin"
+	"github.com/rochaporto/ezgliding/waypoint"
 )
 
 func exit(c int) {
@@ -49,14 +50,14 @@ func main() {
 	airspace, err := plugin.NewPlugin(plugin.ID(cfg.Global.Airspacer))
 	afield, err := plugin.NewPlugin(plugin.ID(cfg.Global.Airfielder))
 	fght, err := plugin.NewPlugin(plugin.ID(cfg.Global.Flighter))
-	waypoint, err := plugin.NewPlugin(plugin.ID(cfg.Global.Waypointer))
+	wpoint, err := plugin.NewPlugin(plugin.ID(cfg.Global.Waypointer))
 	airspace.Init(cfg)
 	afield.Init(cfg)
 	fght.Init(cfg)
-	waypoint.Init(cfg)
+	wpoint.Init(cfg)
 	ctx, err := context.NewContext(cfg, airspace.(common.Airspacer),
 		afield.(airfield.Airfielder), fght.(flight.Flighter),
-		waypoint.(common.Waypointer))
+		wpoint.(waypoint.Waypointer))
 	if err != nil {
 		glog.Errorf("Failed to create context object :: %v", err)
 		exit(-1)

--- a/mock/mock.go
+++ b/mock/mock.go
@@ -28,6 +28,7 @@ import (
 	"github.com/rochaporto/ezgliding/common"
 	"github.com/rochaporto/ezgliding/config"
 	"github.com/rochaporto/ezgliding/flight"
+	"github.com/rochaporto/ezgliding/waypoint"
 )
 
 const (
@@ -47,8 +48,8 @@ type Mock struct {
 	GetFlightFromIDF func(startID int, max int) ([]flight.Flight, error)
 	GetFlightByIDF   func(id int) (flight.Flight, error)
 	PutFlightF       func(flights []flight.Flight) error
-	GetWaypointF     func(regions []string, updatedSince time.Time) ([]common.Waypoint, error)
-	PutWaypointF     func(waypoint []common.Waypoint) error
+	GetWaypointF     func(regions []string, updatedSince time.Time) ([]waypoint.Waypoint, error)
+	PutWaypointF     func(waypoint []waypoint.Waypoint) error
 }
 
 // Init is the mock implementation of common.Pluginer.Init.

--- a/mock/waypoint.go
+++ b/mock/waypoint.go
@@ -22,21 +22,21 @@ package mock
 import (
 	"time"
 
-	"github.com/rochaporto/ezgliding/common"
+	"github.com/rochaporto/ezgliding/waypoint"
 )
 
-// GetWaypoint is the mock implementation of common.Waypointer.GetWaypoint.
-func (mk *Mock) GetWaypoint(regions []string, updatedSince time.Time) ([]common.Waypoint, error) {
+// GetWaypoint is the mock implementation of waypoint.Waypointer.GetWaypoint.
+func (mk *Mock) GetWaypoint(regions []string, updatedSince time.Time) ([]waypoint.Waypoint, error) {
 	if mk.GetWaypointF != nil {
 		return mk.GetWaypointF(regions, updatedSince)
 	}
-	return []common.Waypoint{}, nil
+	return []waypoint.Waypoint{}, nil
 }
 
-// PutWaypoint is the mock implementation of common.Waypointr.PutWaypoint.
-func (mk *Mock) PutWaypoint(waypoint []common.Waypoint) error {
+// PutWaypoint is the mock implementation of waypoint.Waypointr.PutWaypoint.
+func (mk *Mock) PutWaypoint(wpoint []waypoint.Waypoint) error {
 	if mk.PutWaypointF != nil {
-		return mk.PutWaypointF(waypoint)
+		return mk.PutWaypointF(wpoint)
 	}
 	return nil
 }

--- a/mock/waypoint_test.go
+++ b/mock/waypoint_test.go
@@ -24,15 +24,15 @@ import (
 	"testing"
 	"time"
 
-	"github.com/rochaporto/ezgliding/common"
+	"github.com/rochaporto/ezgliding/waypoint"
 )
 
 func TestGetWaypoint(t *testing.T) {
-	waypoints := []common.Waypoint{
-		common.Waypoint{Name: "TestMockWaypoint"},
+	waypoints := []waypoint.Waypoint{
+		waypoint.Waypoint{Name: "TestMockWaypoint"},
 	}
 	mock := Mock{
-		GetWaypointF: func(regions []string, updatedSince time.Time) ([]common.Waypoint, error) {
+		GetWaypointF: func(regions []string, updatedSince time.Time) ([]waypoint.Waypoint, error) {
 			return waypoints, nil
 		},
 	}
@@ -57,12 +57,12 @@ func TestGetWaypointNotImplemented(t *testing.T) {
 }
 
 func TestPutWaypoint(t *testing.T) {
-	waypoints := []common.Waypoint{
-		common.Waypoint{Name: "TestMockWaypoint"},
+	waypoints := []waypoint.Waypoint{
+		waypoint.Waypoint{Name: "TestMockWaypoint"},
 	}
-	var result []common.Waypoint
+	var result []waypoint.Waypoint
 	mock := Mock{
-		PutWaypointF: func(w []common.Waypoint) error {
+		PutWaypointF: func(w []waypoint.Waypoint) error {
 			result = w
 			return nil
 		},

--- a/util/spatial.go
+++ b/util/spatial.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/paulmach/go.geojson"
 	"github.com/rochaporto/ezgliding/airfield"
-	"github.com/rochaporto/ezgliding/common"
+	"github.com/rochaporto/ezgliding/waypoint"
 )
 
 // DMS2Decimal converts the given coordinates from DMS to decimal format.
@@ -62,8 +62,8 @@ func Struct2GeoJSON(features []interface{}) (*geojson.FeatureCollection, error) 
 			return nil, errors.New("geojson convertion not supported")
 		case airfield.Airfield:
 			f = airfield2GeoJSON([]airfield.Airfield{e.(airfield.Airfield)})
-		case common.Waypoint:
-			f = waypoint2GeoJSON([]common.Waypoint{e.(common.Waypoint)})
+		case waypoint.Waypoint:
+			f = waypoint2GeoJSON([]waypoint.Waypoint{e.(waypoint.Waypoint)})
 		}
 		result.AddFeature(f[0])
 	}
@@ -93,7 +93,7 @@ func airfield2GeoJSON(airfields []airfield.Airfield) []*geojson.Feature {
 }
 
 // waypoint2GeoJSON converts the given waypoint to GeoJSON format.
-func waypoint2GeoJSON(waypoints []common.Waypoint) []*geojson.Feature {
+func waypoint2GeoJSON(waypoints []waypoint.Waypoint) []*geojson.Feature {
 	result := []*geojson.Feature{}
 	for _, waypoint := range waypoints {
 		g := geojson.NewPointFeature([]float64{waypoint.Longitude, waypoint.Latitude})
@@ -110,7 +110,7 @@ func waypoint2GeoJSON(waypoints []common.Waypoint) []*geojson.Feature {
 }
 
 // GeoJSON2Struct returns airfield, waypoint, etc objects from the given GeoJSON.
-// The resulting array contains distinct types (airfield.Airfield, common.Waypoint,
+// The resulting array contains distinct types (airfield.Airfield, waypoint.Waypoint,
 // common.Airspace, ...) and the unmarshaling is done with the same rules as
 // described in Struct2GeoJSON.
 func GeoJSON2Struct(json string) ([]interface{}, error) {
@@ -148,8 +148,8 @@ func feature2Airfield(f *geojson.Feature) airfield.Airfield {
 	a.Latitude = f.Geometry.Point[1]
 	return a
 }
-func feature2Waypoint(f *geojson.Feature) common.Waypoint {
-	w := common.Waypoint{
+func feature2Waypoint(f *geojson.Feature) waypoint.Waypoint {
+	w := waypoint.Waypoint{
 		ID: f.PropertyMustString("ID"), Description: f.PropertyMustString("Description"),
 		Name: f.PropertyMustString("Name"), Region: f.PropertyMustString("Region"),
 		Flags: f.PropertyMustInt("Flags"), Elevation: f.PropertyMustInt("Elevation"),

--- a/util/spatial_test.go
+++ b/util/spatial_test.go
@@ -24,7 +24,7 @@ import (
 	"testing"
 
 	"github.com/rochaporto/ezgliding/airfield"
-	"github.com/rochaporto/ezgliding/common"
+	"github.com/rochaporto/ezgliding/waypoint"
 )
 
 type DMS2DecimalTest struct {
@@ -85,7 +85,7 @@ var struct2GeoJSONTests = []Struct2GeoJSONTest{
 	Struct2GeoJSONTest{
 		"simple waypoint conversion",
 		[]interface{}{
-			common.Waypoint{
+			waypoint.Waypoint{
 				ID: "FURKAP", Name: "FURKAP", Description: "FURKAPASS PASSHOEHE", Elevation: 2432,
 				Latitude: 46.572, Longitude: 8.415, Region: "CH", Flags: 0,
 			},
@@ -98,7 +98,7 @@ var struct2GeoJSONTests = []Struct2GeoJSONTest{
 			airfield.Airfield{ID: "HABER", ShortName: "HABER", Name: "HABERE POC69",
 				Region: "FR", ICAO: "HHHH", Flags: 1032, Catalog: 69, Length: 900, Elevation: 1113,
 				Runway: "0119", Frequency: 122.5, Latitude: 46.270, Longitude: 6.463},
-			common.Waypoint{
+			waypoint.Waypoint{
 				ID: "FURKAP", Name: "FURKAP", Description: "FURKAPASS PASSHOEHE", Elevation: 2432,
 				Latitude: 46.572, Longitude: 8.415, Region: "CH", Flags: 0,
 			},

--- a/waypoint/waypoint.go
+++ b/waypoint/waypoint.go
@@ -17,7 +17,8 @@
 //
 // Author: Ricardo Rocha <rocha.porto@gmail.com>
 
-package common
+// Package waypoint holds all waypoint interfaces and types/structs.
+package waypoint
 
 import (
 	"time"

--- a/web/handler.go
+++ b/web/handler.go
@@ -28,7 +28,7 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/rochaporto/ezgliding/airfield"
-	"github.com/rochaporto/ezgliding/common"
+	"github.com/rochaporto/ezgliding/waypoint"
 )
 
 // makeHandler is a common wrapper for all handlers.
@@ -106,8 +106,8 @@ func (srv *Server) waypointHandler(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
-	waypoint := srv.ctx.Waypoint
-	waypoints, err := waypoint.(common.Waypointer).GetWaypoint(params["region"], updated)
+	wpoint := srv.ctx.Waypoint
+	waypoints, err := wpoint.(waypoint.Waypointer).GetWaypoint(params["region"], updated)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return

--- a/web/web_test.go
+++ b/web/web_test.go
@@ -30,11 +30,11 @@ import (
 	"time"
 
 	"github.com/rochaporto/ezgliding/airfield"
-	"github.com/rochaporto/ezgliding/common"
 	"github.com/rochaporto/ezgliding/config"
 	"github.com/rochaporto/ezgliding/context"
 	"github.com/rochaporto/ezgliding/mock"
 	"github.com/rochaporto/ezgliding/util"
+	"github.com/rochaporto/ezgliding/waypoint"
 )
 
 type ServerTest struct {
@@ -77,7 +77,7 @@ var serverTests = []ServerTest{
 	{
 		"query waypoint json",
 		[]interface{}{
-			common.Waypoint{
+			waypoint.Waypoint{
 				ID: "FURKAP", Name: "FURKAP", Description: "FURKAPASS PASSHOEHE", Elevation: 2432,
 				Latitude: 46.572, Longitude: 8.415, Region: "CH", Flags: 0,
 			},
@@ -91,7 +91,7 @@ var serverTests = []ServerTest{
 	{
 		"query waypoint json zipped",
 		[]interface{}{
-			common.Waypoint{
+			waypoint.Waypoint{
 				ID: "FURKAP", Name: "FURKAP", Description: "FURKAPASS PASSHOEHE", Elevation: 2432,
 				Latitude: 46.572, Longitude: 8.415, Region: "CH", Flags: 0,
 			},
@@ -160,20 +160,20 @@ var serverTests = []ServerTest{
 
 func serverFromTest(test ServerTest) Server {
 	airfields := []airfield.Airfield{}
-	waypoints := []common.Waypoint{}
+	waypoints := []waypoint.Waypoint{}
 	for _, a := range test.dt {
 		switch a.(type) {
 		case airfield.Airfield:
 			airfields = append(airfields, a.(airfield.Airfield))
-		case common.Waypoint:
-			waypoints = append(waypoints, a.(common.Waypoint))
+		case waypoint.Waypoint:
+			waypoints = append(waypoints, a.(waypoint.Waypoint))
 		}
 	}
 	mock := &mock.Mock{
 		GetAirfieldF: func(regions []string, updatedSince time.Time) ([]airfield.Airfield, error) {
 			return airfields, test.perr
 		},
-		GetWaypointF: func(regions []string, updatedSince time.Time) ([]common.Waypoint, error) {
+		GetWaypointF: func(regions []string, updatedSince time.Time) ([]waypoint.Waypoint, error) {
 			return waypoints, test.perr
 		},
 	}

--- a/welt2000/welt2000.go
+++ b/welt2000/welt2000.go
@@ -35,9 +35,9 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/rochaporto/ezgliding/airfield"
-	"github.com/rochaporto/ezgliding/common"
 	"github.com/rochaporto/ezgliding/config"
 	"github.com/rochaporto/ezgliding/util"
+	"github.com/rochaporto/ezgliding/waypoint"
 	"github.com/rochaporto/rss"
 )
 
@@ -51,7 +51,7 @@ type Release struct {
 	Date      time.Time
 	Source    string
 	Airfields []airfield.Airfield
-	Waypoints []common.Waypoint
+	Waypoints []waypoint.Waypoint
 }
 
 var rssURL = "http://www.segelflug.de/vereine/welt2000/content/en/news/updates.xml"
@@ -123,7 +123,7 @@ func (wt *Welt2000) PutAirfield(airfields []airfield.Airfield) error {
 
 // GetWaypoint follows airfield.GetWaypoint().
 // FIXME: use region
-func (wt *Welt2000) GetWaypoint(regions []string, updatedSince time.Time) ([]common.Waypoint, error) {
+func (wt *Welt2000) GetWaypoint(regions []string, updatedSince time.Time) ([]waypoint.Waypoint, error) {
 	glog.V(10).Infof("GetWaypoint with regions %v and updatedSince %v", regions, updatedSince)
 	releases, err := List(wt.rssURL)
 	if err != nil {
@@ -144,7 +144,7 @@ func (wt *Welt2000) GetWaypoint(regions []string, updatedSince time.Time) ([]com
 	for _, v := range regions {
 		m[v] = true
 	}
-	var filtered []common.Waypoint
+	var filtered []waypoint.Waypoint
 	for _, a := range release.Waypoints {
 		if _, ok := m[a.Region]; ok {
 			filtered = append(filtered, a)
@@ -157,8 +157,8 @@ func (wt *Welt2000) GetWaypoint(regions []string, updatedSince time.Time) ([]com
 	return release.Waypoints, err
 }
 
-// PutWaypoint follows airfield.PutWaypoint().
-func (wt *Welt2000) PutWaypoint(waypoints []common.Waypoint) error {
+// PutWaypoint follows waypoint.PutWaypoint().
+func (wt *Welt2000) PutWaypoint(waypoints []waypoint.Waypoint) error {
 	return errors.New("not available for welt2000 plugin")
 }
 
@@ -306,7 +306,7 @@ func (r *Release) runwayType2Bit(t uint8) int {
 }
 
 func (r *Release) parseWaypoint(line string) error {
-	waypoint := common.Waypoint{
+	waypoint := waypoint.Waypoint{
 		Name: strings.Trim(line[0:6], " "), ID: strings.Trim(line[0:6], " "),
 		Description: strings.Trim(line[7:41], " "),
 		Latitude:    util.DMS2Decimal(line[45:52]), Longitude: util.DMS2Decimal(line[52:60]),

--- a/welt2000/welt2000_test.go
+++ b/welt2000/welt2000_test.go
@@ -29,8 +29,8 @@ import (
 	"time"
 
 	"github.com/rochaporto/ezgliding/airfield"
-	"github.com/rochaporto/ezgliding/common"
 	"github.com/rochaporto/ezgliding/config"
+	"github.com/rochaporto/ezgliding/waypoint"
 )
 
 var GMT, _ = time.LoadLocation("GMT")
@@ -154,7 +154,7 @@ type GetWaypointTest struct {
 	rss string
 	rg  string
 	d   time.Time
-	rs  []common.Waypoint
+	rs  []waypoint.Waypoint
 	err bool
 }
 
@@ -164,8 +164,8 @@ var getWaypointTests = []GetWaypointTest{
 		"./t/test-releases-list.xml",
 		"CH",
 		time.Time{},
-		[]common.Waypoint{
-			common.Waypoint{
+		[]waypoint.Waypoint{
+			waypoint.Waypoint{
 				ID: "FURKAP", Name: "FURKAP", Description: "FURKAPASS PASSHOEHE", Elevation: 2432,
 				Latitude: 46.57277777777778, Longitude: 8.415277777777778, Region: "CH",
 				Update: time.Date(2014, time.February, 24, 12, 0, 0, 0, GMT),
@@ -178,7 +178,7 @@ var getWaypointTests = []GetWaypointTest{
 		"./t/test-releases-list.xml",
 		"CH",
 		time.Date(2014, time.February, 25, 0, 0, 0, 0, time.UTC),
-		[]common.Waypoint{},
+		[]waypoint.Waypoint{},
 		false,
 	},
 	{"get waypoint missing rss",
@@ -186,7 +186,7 @@ var getWaypointTests = []GetWaypointTest{
 		"./t/missing-release-list.xml",
 		"CH",
 		time.Time{},
-		[]common.Waypoint{},
+		[]waypoint.Waypoint{},
 		true,
 	},
 	{"get waypoint missing release",
@@ -194,7 +194,7 @@ var getWaypointTests = []GetWaypointTest{
 		"./t/test-releases-list.xml",
 		"CH",
 		time.Time{},
-		[]common.Waypoint{},
+		[]waypoint.Waypoint{},
 		true,
 	},
 	{"get waypoint with 0 values for region",
@@ -202,7 +202,7 @@ var getWaypointTests = []GetWaypointTest{
 		"./t/test-releases-list.xml",
 		"ZZ",
 		time.Time{},
-		[]common.Waypoint{},
+		[]waypoint.Waypoint{},
 		false,
 	},
 }
@@ -220,7 +220,7 @@ func TestGetWaypoint(t *testing.T) {
 			t.Errorf("Failed to initialize plugin :: %v", err)
 		}
 
-		var waypoints []common.Waypoint
+		var waypoints []waypoint.Waypoint
 		waypoints, err = plugin.GetWaypoint([]string{test.rg}, test.d)
 		if err != nil && test.err {
 			continue
@@ -510,13 +510,13 @@ func TestParseCatalogNumber(t *testing.T) {
 func TestParseWaypoint(t *testing.T) {
 	r := Release{}
 	r.Parse([]byte("FURKAP FURKAPASS PASSHOEHE               2432N463422E0082455CHQ6"))
-	waypoint := r.Waypoints[0]
-	expected := common.Waypoint{
+	wpoint := r.Waypoints[0]
+	expected := waypoint.Waypoint{
 		Name: "FURKAP", ID: "FURKAP", Description: "FURKAPASS PASSHOEHE",
 		Latitude: 46.57277777777778, Longitude: 8.415277777777778, Elevation: 2432, Region: "CH",
 	}
-	if waypoint != expected {
-		t.Errorf("Parse failed for waypoint: got %v instead of %v", waypoint, expected)
+	if wpoint != expected {
+		t.Errorf("Parse failed for waypoint: got %v instead of %v", wpoint, expected)
 	}
 }
 


### PR DESCRIPTION
refactors all waypoint interfaces and types/structs into their own pkg
(was in common). this is part of the refactoring effort to get rid of
common.

Implements #69.