### PR TITLE
strip header prefixes from values.

### DIFF
--- a/flight/igc.go
+++ b/flight/igc.go
@@ -270,32 +270,32 @@ func (p *IGCParser) parseH(line string, f *Flight) error {
 		}
 		f.Header.FixAccuracy, err = strconv.ParseInt(line[5:8], 10, 64)
 	case "PLT":
-		f.Header.Pilot = line[5:]
+		f.Header.Pilot = stripUpTo(line[5:], ":")
 	case "CM2":
-		f.Header.Crew = line[5:]
+		f.Header.Crew = stripUpTo(line[5:], ":")
 	case "GTY":
-		f.Header.GliderType = line[5:]
+		f.Header.GliderType = stripUpTo(line[5:], ":")
 	case "GID":
-		f.Header.GliderID = line[5:]
+		f.Header.GliderID = stripUpTo(line[5:], ":")
 	case "DTM":
 		if len(line) < 8 {
 			return fmt.Errorf("line too short :: %v", line)
 		}
-		f.Header.GPSDatum = line[5:8]
+		f.Header.GPSDatum = stripUpTo(line[5:], ":")
 	case "RFW":
-		f.Header.FirmwareVersion = line[5:]
+		f.Header.FirmwareVersion = stripUpTo(line[5:], ":")
 	case "RHW":
-		f.Header.HardwareVersion = line[5:]
+		f.Header.HardwareVersion = stripUpTo(line[5:], ":")
 	case "FTY":
-		f.Header.FlightRecorder = line[5:]
+		f.Header.FlightRecorder = stripUpTo(line[5:], ":")
 	case "GPS":
 		f.Header.GPS = line[5:]
 	case "PRS":
-		f.Header.PressureSensor = line[5:]
+		f.Header.PressureSensor = stripUpTo(line[5:], ":")
 	case "CID":
-		f.Header.CompetitionID = line[5:]
+		f.Header.CompetitionID = stripUpTo(line[5:], ":")
 	case "CCL":
-		f.Header.CompetitionClass = line[5:]
+		f.Header.CompetitionClass = stripUpTo(line[5:], ":")
 	default:
 		err = fmt.Errorf("unknown error record :: %v", line)
 	}
@@ -367,4 +367,12 @@ func (p *IGCParser) parseL(line string, f *Flight) error {
 	}
 	f.Logbook = append(f.Logbook, LogEntry{Type: line[1:4], Text: line[4:]})
 	return nil
+}
+
+func stripUpTo(s string, sep string) string {
+	i := strings.Index(s, sep)
+	if i == -1 {
+		return s
+	}
+	return s[i+1:]
 }

--- a/flight/igc_test.go
+++ b/flight/igc_test.go
@@ -40,25 +40,25 @@ var parseTests = []IGCParseTest{
 AFLA001Some Additional Data
 HFDTE010203
 HFFXA500
-HFPLTEZ PILOT
-HFCM2EZ CREW
-HFGTYEZ TYPE
-HFGIDEZ ID
-HFDTM100
-HFRFWv 0.1
-HFRHWv 0.2
-HFFTYEZ RECORDER,001
+HFPLTPilotincharge:EZ PILOT
+HFCM2Crew2:EZ CREW
+HFGTYGliderType:EZ TYPE
+HFGIDGliderID:EZ ID
+HFDTM100GPSDatum:WGS84
+HFRFWFirmwareVersion:v 0.1
+HFRHWHardwareVersion:v 0.2
+HFFTYFRType:EZ RECORDER,001
 HFGPSEZ GPS,002,12,5000
-HFPRSEZ PRESSURE
-HFCIDEZ COMPID
-HFCCLEZ COMPCLASS
+HFPRSPressAltSensor:EZ PRESSURE
+HFCIDCompetitionID:EZ COMPID
+HFCCLCompetitionClass:EZ COMPCLASS
 `,
 		Flight{
 			Header: Header{
 				Manufacturer: "FLA", UniqueID: "001", AdditionalData: "Some Additional Data",
 				Date:        time.Date(2003, time.February, 01, 0, 0, 0, 0, time.UTC),
 				FixAccuracy: 500, Pilot: "EZ PILOT", Crew: "EZ CREW",
-				GliderType: "EZ TYPE", GliderID: "EZ ID", GPSDatum: "100",
+				GliderType: "EZ TYPE", GliderID: "EZ ID", GPSDatum: "WGS84",
 				FirmwareVersion: "v 0.1", HardwareVersion: "v 0.2",
 				FlightRecorder: "EZ RECORDER,001", GPS: "EZ GPS,002,12,5000",
 				PressureSensor: "EZ PRESSURE", CompetitionID: "EZ COMPID",
@@ -309,6 +309,14 @@ func TestIGCParse(t *testing.T) {
 			t.Errorf("%v failed :: expected\n%+v\ngot\n%+v", test.t, test.r, result)
 			continue
 		}
+	}
+}
+
+func TestStripUpToMissing(t *testing.T) {
+	s := "nocolonhere"
+	r := stripUpTo(s, ":")
+	if r != s {
+		t.Errorf("expected %v got %v", s, r)
 	}
 }
 


### PR DESCRIPTION
strip things like 'Pilotincharge', 'CompetitionID', etc from the header
values (it's in the spec). do this by stripping all up to ':', which is
the separator in all cases.

also fixes parsing of GPSDatum.

Fixes #68.