### PR TITLE
add timezone to flight.Header, igc tz parsing.

### DIFF
--- a/flight/flight.go
+++ b/flight/flight.go
@@ -87,6 +87,7 @@ type Header struct {
 	PressureSensor   string
 	CompetitionID    string
 	CompetitionClass string
+	Timezone         time.Location
 }
 
 // Point represents a gps read (single point in the flight track).

--- a/flight/igc.go
+++ b/flight/igc.go
@@ -296,8 +296,14 @@ func (p *IGCParser) parseH(line string, f *Flight) error {
 		f.Header.CompetitionID = stripUpTo(line[5:], ":")
 	case "CCL":
 		f.Header.CompetitionClass = stripUpTo(line[5:], ":")
+	case "TZN":
+		z, err := strconv.ParseFloat(stripUpTo(line[5:], ":"), 64)
+		if err != nil {
+			return err
+		}
+		f.Header.Timezone = *time.FixedZone("", int(z*3600))
 	default:
-		err = fmt.Errorf("unknown error record :: %v", line)
+		err = fmt.Errorf("unknown record :: %v", line)
 	}
 
 	return err

--- a/flight/igc_test.go
+++ b/flight/igc_test.go
@@ -52,6 +52,7 @@ HFGPSEZ GPS,002,12,5000
 HFPRSPressAltSensor:EZ PRESSURE
 HFCIDCompetitionID:EZ COMPID
 HFCCLCompetitionClass:EZ COMPCLASS
+HFTZNTimezone:2.00
 `,
 		Flight{
 			Header: Header{
@@ -62,7 +63,7 @@ HFCCLCompetitionClass:EZ COMPCLASS
 				FirmwareVersion: "v 0.1", HardwareVersion: "v 0.2",
 				FlightRecorder: "EZ RECORDER,001", GPS: "EZ GPS,002,12,5000",
 				PressureSensor: "EZ PRESSURE", CompetitionID: "EZ COMPID",
-				CompetitionClass: "EZ COMPCLASS",
+				CompetitionClass: "EZ COMPCLASS", Timezone: *time.FixedZone("", 2*3600),
 			},
 			K:          map[time.Time]map[string]string{},
 			Events:     map[time.Time]map[string]string{},
@@ -87,6 +88,8 @@ HFCCLCompetitionClass:EZ COMPCLASS
 		"HFDTM20", Flight{}, true},
 	{"H record failure unknown field",
 		"HFZZZaaa", Flight{}, true},
+	{"H record failure bad timezone",
+		"HFTZNaa", Flight{}, true},
 	{
 		"basic flight test",
 		`


### PR DESCRIPTION
adds a new Timezone field to the flight.Header struct. also enables
parsing of the TZN header record in igc files.

Fixes #86.